### PR TITLE
Add a .MarshalJSONBuf interface to reduce bytes.Buffer allocations

### DIFF
--- a/inception/reflect.go
+++ b/inception/reflect.go
@@ -51,7 +51,12 @@ func NewStructInfo(obj interface{}) *StructInfo {
 	}
 }
 
+type MarshalerBuf interface {
+	MarshalJSONBuf(buf *bytes.Buffer) error
+}
+
 var marshalerType = reflect.TypeOf(new(json.Marshaler)).Elem()
+var marshalerBufType = reflect.TypeOf(new(MarshalerBuf)).Elem()
 var unmarshalerType = reflect.TypeOf(new(json.Unmarshaler)).Elem()
 
 func extractFields(obj interface{}) []*StructField {


### PR DESCRIPTION
Adds a new interface, `MarshalJSONBuf` which takes a `bytes.Buffer` as a parameter, instead of returning `[]bytes`.

This is about ~16% faster on my laptop for the `goser` Log structure.

```
BenchmarkFFMarshalJSON    200000         10164 ns/op      60.60 MB/s        4227 B/op         46 allocs/op
BenchmarkFFMarshalJSONBuf     200000          8697 ns/op      70.83 MB/s        1959 B/op         42 allocs/op
```
