### PR TITLE
if the field is not exported, or set to a name of `-`, skip it

### DIFF
--- a/inception/reflect.go
+++ b/inception/reflect.go
@@ -65,11 +65,20 @@ func extractFields(obj interface{}) []*StructField {
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
 
+		// based on checks in encoding/json/encode.go, we don't export everything.
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+
 		jsonName := f.Name
 		omitEmpty := false
 		forceString := false
 
 		tag := f.Tag.Get("json")
+
+		if tag == "-" {
+			continue
+		}
 
 		if tag != "" {
 			tagName, opts := parseTag(tag)


### PR DESCRIPTION
- Make sure field is exported.
- Fixes regression in not skipping `-` JSON named fields.
