### PR TITLE
Improve go stripe perf

### DIFF
--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -190,8 +190,7 @@ func CreateMarshalJSON(ic *Inception, si *StructInfo) error {
 		out += "}" + "\n"
 
 		// JsonName is already escaped and quoted.
-		out += "buf.WriteString(`" + f.JsonName + "`)" + "\n"
-		out += "buf.WriteString(`:`)" + "\n"
+		out += "buf.WriteString(`" + f.JsonName + ":`)" + "\n"
 		out += getValue(ic, f)
 		if f.OmitEmpty {
 			out += "}" + "\n"


### PR DESCRIPTION
![](http://i.imgur.com/WemYD.gif)
- **Improves `go.stripe` Marshal performance by ~81%**, it is now 2.11x faster than standard `encoding/json`.
- Add native support for `Bool`, `Ptr` and `Slice`.
