### PR TITLE
Fix panic on short relpath

### DIFF
--- a/generator/inceptionmain.go
+++ b/generator/inceptionmain.go
@@ -103,7 +103,7 @@ func (im *InceptionMain) Generate(packageName string, si []*StructInfo) error {
 	importName, err := getImportName(im.inputPath)
 
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// for `go run` to work, we must have a file ending in ".go".


### PR DESCRIPTION
if filepath.RelPath returns a short string, the code would panic.
