### PR TITLE
encoder: dereference pointer

### DIFF
--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -19,8 +19,9 @@ package ffjsoninception
 
 import (
 	"fmt"
-	"github.com/pquerna/ffjson/pills"
 	"reflect"
+
+	"github.com/pquerna/ffjson/pills"
 )
 
 func typeInInception(ic *Inception, typ reflect.Type) bool {
@@ -128,7 +129,7 @@ func getGetInnerValue(ic *Inception, name string, typ reflect.Type) string {
 	case reflect.Ptr,
 		reflect.Interface:
 		out += "if " + name + "!= nil {" + "\n"
-		out += getGetInnerValue(ic, name, typ.Elem())
+		out += getGetInnerValue(ic, "*"+name, typ.Elem())
 		out += "} else {" + "\n"
 		out += "buf.WriteString(`null`)" + "\n"
 		out += "}" + "\n"


### PR DESCRIPTION
Pointers were not derefenced and as a result generated incorrect code.

Example struct which fails:

```
type T Struct {
    Value *int64
}
```
