### PR TITLE
Stub new methods out in `_expose.go`, and delete output file before running inception.

### DIFF
--- a/generator/inceptionmain.go
+++ b/generator/inceptionmain.go
@@ -56,6 +56,11 @@ const ffjsonExposeTemplate = `
 
 package {{.PackageName}}
 
+import (
+	"errors"
+	fflib "github.com/pquerna/ffjson/fflib/v1"
+)
+
 func FFJSONExpose() []interface{} {
 	rv := make([]interface{}, 0)
 {{range .StructNames}}
@@ -63,6 +68,25 @@ func FFJSONExpose() []interface{} {
 {{end}}
 	return rv
 }
+
+{{range .StructNames}}
+func (v *{{.}}) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("stub function")
+}
+
+func (v *{{.}}) MarshalJSONBuf(buf fflib.EncodingBuffer) error {
+	return errors.New("stub function")
+}
+
+func (v *{{.}}) UnmarshalJSON(input []byte) error{
+	return errors.New("stub function")
+}
+
+func (v *{{.}}) UnmarshalJSONFFLexer(fs *fflib.FFLexer, state fflib.FFParseState) error {
+	return errors.New("stub function")
+}
+
+{{end}}
 `
 
 type templateCtx struct {
@@ -210,6 +234,8 @@ func (im *InceptionMain) Generate(packageName string, si []*StructInfo) error {
 func (im *InceptionMain) Run() error {
 	var out bytes.Buffer
 	var errOut bytes.Buffer
+
+	os.Remove(im.outputPath)
 
 	cmd := exec.Command(im.goCmd, "run", "-a", im.TempMainPath)
 	cmd.Stdout = &out


### PR DESCRIPTION
Fixes #42
