### PR TITLE
Add Fuzz Tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 install:
   - go get -d -v ./...
   - go get -u github.com/stretchr/testify/require
+  - go get -u github.com/google/gofuzz
 
 script: make clean && make test && make test
 

--- a/tests/ff.go
+++ b/tests/ff.go
@@ -138,6 +138,14 @@ type XboolTagged struct {
 }
 
 // ffjson: skip
+type TMapStringString struct {
+	X map[string]string
+}
+type XMapStringString struct {
+	X map[string]string
+}
+
+// ffjson: skip
 type Tbool struct {
 	X bool
 }
@@ -151,6 +159,14 @@ type Tint struct {
 }
 type Xint struct {
 	Tint
+}
+
+// ffjson: skip
+type Tbyte struct {
+	X byte
+}
+type Xbyte struct {
+	Tbyte
 }
 
 // ffjson: skip
@@ -248,6 +264,146 @@ type Tfloat64 struct {
 type Xfloat64 struct {
 	Tfloat64
 }
+
+// Arrays
+/*
+// ffjson: skip
+type ATduration struct {
+	X []time.Duration
+}
+type AXduration struct {
+	X []time.Duration
+}
+*/
+// ffjson: skip
+type ATbool struct {
+	X []bool
+}
+type AXbool struct {
+	ATbool
+}
+
+// ffjson: skip
+type ATint struct {
+	X []int
+}
+type AXint struct {
+	ATint
+}
+
+// ffjson: skip
+type ATbyte struct {
+	X []byte
+}
+type AXbyte struct {
+	ATbyte
+}
+
+// ffjson: skip
+type ATint8 struct {
+	X []int8
+}
+type AXint8 struct {
+	ATint8
+}
+
+// ffjson: skip
+type ATint16 struct {
+	X []int16
+}
+type AXint16 struct {
+	ATint16
+}
+
+// ffjson: skip
+type ATint32 struct {
+	X []int32
+}
+type AXint32 struct {
+	ATint32
+}
+
+// ffjson: skip
+type ATint64 struct {
+	X []int64
+}
+type AXint64 struct {
+	ATint64
+}
+
+// ffjson: skip
+type ATuint struct {
+	X []uint
+}
+type AXuint struct {
+	ATuint
+}
+
+// ffjson: skip
+type ATuint8 struct {
+	X []uint8
+}
+type AXuint8 struct {
+	ATuint8
+}
+
+// ffjson: skip
+type ATuint16 struct {
+	X []uint16
+}
+type AXuint16 struct {
+	ATuint16
+}
+
+// ffjson: skip
+type ATuint32 struct {
+	X []uint32
+}
+type AXuint32 struct {
+	ATuint32
+}
+
+// ffjson: skip
+type ATuint64 struct {
+	X []uint64
+}
+type AXuint64 struct {
+	ATuint64
+}
+
+// ffjson: skip
+type ATuintptr struct {
+	X []uintptr
+}
+type AXuintptr struct {
+	ATuintptr
+}
+
+// ffjson: skip
+type ATfloat32 struct {
+	X []float32
+}
+type AXfloat32 struct {
+	ATfloat32
+}
+
+// ffjson: skip
+type ATfloat64 struct {
+	X []float64
+}
+type AXfloat64 struct {
+	ATfloat64
+}
+
+/*
+// ffjson: skip
+type ATtime struct {
+	X []time.Time
+}
+type AXtime struct {
+	ATtime
+}
+*/
 
 // Tests from golang test suite
 type Optionals struct {
@@ -465,4 +621,93 @@ type BugZ struct {
 	BugA
 	BugC
 	BugY // Contains a tagged S field through BugD; should not dominate.
+}
+
+type FfFuzz struct {
+	A uint8
+	B uint16
+	C uint32
+	D uint64
+
+	E int8
+	F int16
+	G int32
+	H int64
+
+	I float32
+	J float64
+
+	M byte
+	N rune
+
+	O int
+	P uint
+	Q string
+	R bool
+	S time.Time
+	U map[string]string
+
+	Ap *uint8
+	Bp *uint16
+	Cp *uint32
+	Dp *uint64
+
+	Ep *int8
+	Fp *int16
+	Gp *int32
+	Hp *int64
+
+	Ip *float32
+	Jp *float64
+
+	Mp *byte
+	Np *rune
+
+	Op *int
+	Pp *uint
+	Qp *string
+	Rp *bool
+	Sp *time.Time
+
+	Aa []uint8
+	Ba []uint16
+	Ca []uint32
+	Da []uint64
+
+	Ea []int8
+	Fa []int16
+	Ga []int32
+	Ha []int64
+
+	Ia []float32
+	Ja []float64
+
+	Ma []byte
+	Na []rune
+
+	Oa []int
+	Pa []uint
+	Qa []string
+	Ra []bool
+
+	Aap []*uint8
+	Bap []*uint16
+	Cap []*uint32
+	Dap []*uint64
+
+	Eap []*int8
+	Fap []*int16
+	Gap []*int32
+	Hap []*int64
+
+	Iap []*float32
+	Jap []*float64
+
+	Map []*byte
+	Nap []*rune
+
+	Oap []*int
+	Pap []*uint
+	Qap []*string
+	Rap []*bool
 }

--- a/tests/ff_string_test.go
+++ b/tests/ff_string_test.go
@@ -31,6 +31,18 @@ func TestString(t *testing.T) {
 	testType(t, &TmystringPtr{}, &XmystringPtr{})
 }
 
+func TestMapStringString(t *testing.T) {
+	t.Skip("Skipped because of issue #66")
+	m := map[string]string{"陫ʋsş\")珷<ºɖgȏ哙ȍ": "2ħ籦ö嗏ʑ>季"}
+	testCycle(t, &TMapStringString{X: m}, &XMapStringString{X: m})
+}
+
+func TestMapStringStringLong(t *testing.T) {
+	t.Skip("Skipped because of issue #66")
+	m := map[string]string{"ɥ³ƞsɁ8^ʥǔTĪȸŹă": "ɩÅ議Ǹ轺@)蓳嗘TʡȂ", "丯Ƙ枛牐ɺ皚|": "\\p[", "ȉ": "ģ毋Ó6ǳ娝嘚", "ʒUɦOŖ": "斎AO6ĴC浔Ű壝ž", "/C龷ȪÆl殛瓷雼浢Ü礽绅": "D¡", "Lɋ聻鎥ʟ<$洅ɹ7\\弌Þ帺萸Do©": "A", "yǠ/淹\\韲翁&ʢsɜ": "`诫z徃鷢6ȥ啕禗Ǐ2啗塧ȱ蓿彭聡A", "瓧嫭塓烀罁胾^拜": "ǒɿʒ刽ŉ掏1ſ盷褎weǇ", "姥呄鐊唊飙Ş-U圴÷a/ɔ}摁(": "瓘ǓvjĜ蛶78Ȋ²@H", "Ĳ斬³;": "鯿r", "勽Ƙq/Ź u衲": "ŭǲ鯰硰{舁", "枊a8衍`Ĩɘ.蘯6ċV夸eɑeʤ脽ě": "6/ʕVŚ(ĿȊ甞谐颋ǅSǡƏS$+", "1ØœȠƬQg鄠": "军g>郵[+扴ȨŮ+朷Ǝ膯ǉ", "礶惇¸t颟.鵫ǚ灄鸫rʤî萨z": "", "ȶ网棊ʢ=wǕɳɷ9Ì": "'WKw(ğ儴Ůĺ}潷ʒ胵輓Ɔ", "}ȧ外ĺ稥氹Ç|¶鎚¡ Ɠ(嘒ėf倐": "窮秳ķ蟒苾h^", "?瞲Ť倱<įXŋ朘瑥A徙": "nh0åȂ町恰ǌ揠8ǉ黳鈫ʕ禒", "丩ŽoǠŻʘY賃ɪ鐊": "ľǎɳ,ǿ飏騀呣ǎ", "ȇe媹Hǝ呮}臷Ľð»ųKĵ": "踪鄌eÞȦY籎顒ǥŴ唼Ģ猇õǶț", "偐ę腬瓷碑=ɉ鎷卩蝾H韹寬娬ï瓼猀2": "ǰ溟ɴ扵閝ȝ鐵儣廡ɑ龫`劳", "ʮ馜ü": "", "șƶ4ĩĉş蝿ɖȃ賲鐅臬dH巧": "_瀹鞎sn芞QÄȻȊ+?", "E@Ȗs«ö": "蚛隖<ǶĬ4y£軶ǃ*ʙ嫙&蒒5靇C'", "忄*齧獚敆Ȏ": "螩B", "圠=l畣潁谯耨V6&]鴍Ɋ恧ȭ%ƎÜ": "涽託仭w-檮", "ʌ鴜": "琔n宂¬轚9Ȏ瀮昃2Ō¾\\", "ƅTG": "ǺƶȤ^}穠C]躢|)黰eȪ嵛4$%Q", "ǹ_Áȉ彂Ŵ廷s": "", "t莭琽§ć\\ ïì": "", "擓ƖHVe熼'FD剂讼ɓȌʟni酛": "/ɸɎ R§耶FfBls3!", "狞夌碕ʂɭ": "Ƽ@hDrȮO励鹗塢", "ʁgɸ=ǤÆ": "?讦ĭÐ", "陫ʋsş\")珷<ºɖgȏ哙ȍ": "2ħ籦ö嗏ʑ>季", "": "昕Ĭ", "Ⱦǳ@ùƸʋŀ": "ǐƲE'iþŹʣy豎@ɀ羭,铻OŤǢʭ", ">犵殇ŕ-Ɂ圯W:ĸ輦唊#v铿ʩȂ4": "屡ʁ", "1Rƥ贫d飼$俊跾|@?鷅bȻN": "H炮掊°nʮ閼咎櫸eʔŊƞ究:ho", "ƻ悖ȩ0Ƹ[": "Ndǂ>5姣>懔%熷谟þ蛯ɰ", "ŵw^Ü郀叚Fi皬择": ":5塋訩塶\"=y钡n)İ笓", "'容": "誒j剐", "猤痈C*ĕ": "鴈o_鹈ɹ坼É/pȿŘ阌"}
+	testCycle(t, &TMapStringString{X: m}, &XMapStringString{X: m})
+}
+
 func TestStringEscapedControlCharacter(t *testing.T) {
 	testExpectedXVal(t,
 		"\x12 escaped control character",
@@ -42,6 +54,13 @@ func TestStringOneByteUTF8(t *testing.T) {
 	testExpectedXVal(t,
 		", one-byte UTF-8",
 		`\u002c one-byte UTF-8`,
+		&Xstring{})
+}
+
+func TestStringUtf8Escape(t *testing.T) {
+	testExpectedXVal(t,
+		"2ħ籦ö嗏ʑ>嫀",
+		`2ħ籦ö嗏ʑ\u003e嫀`,
 		&Xstring{})
 }
 

--- a/tests/fuzz_test.go
+++ b/tests/fuzz_test.go
@@ -1,0 +1,397 @@
+/**
+ *  Copyright 2014 Paul Querna, Klaus Post
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package tff
+
+import (
+	"encoding/json"
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+type Fuzz struct {
+	A uint8
+	B uint16
+	C uint32
+	D uint64
+
+	E int8
+	F int16
+	G int32
+	H int64
+
+	I float32
+	J float64
+
+	M byte
+	N rune
+
+	O int
+	P uint
+	Q string
+	R bool
+	S time.Time
+	U map[string]string
+
+	Ap *uint8
+	Bp *uint16
+	Cp *uint32
+	Dp *uint64
+
+	Ep *int8
+	Fp *int16
+	Gp *int32
+	Hp *int64
+
+	Ip *float32
+	Jp *float64
+
+	Mp *byte
+	Np *rune
+
+	Op *int
+	Pp *uint
+	Qp *string
+	Rp *bool
+	Sp *time.Time
+
+	Aa []uint8
+	Ba []uint16
+	Ca []uint32
+	Da []uint64
+
+	Ea []int8
+	Fa []int16
+	Ga []int32
+	Ha []int64
+
+	Ia []float32
+	Ja []float64
+
+	Ma []byte
+	Na []rune
+
+	Oa []int
+	Pa []uint
+	Qa []string
+	Ra []bool
+
+	Aap []*uint8
+	Bap []*uint16
+	Cap []*uint32
+	Dap []*uint64
+
+	Eap []*int8
+	Fap []*int16
+	Gap []*int32
+	Hap []*int64
+
+	Iap []*float32
+	Jap []*float64
+
+	Map []*byte
+	Nap []*rune
+
+	Oap []*int
+	Pap []*uint
+	Qap []*string
+	Rap []*bool
+}
+
+// Return a time no later than 5000 years from unix datum.
+// JSON cannot handle dates after year 9999.
+func fuzzTime(t *time.Time, c fuzz.Continue) {
+	var sec, nsec int64
+	c.Fuzz(&sec)
+	c.Fuzz(&nsec)
+	// No more than 5000 years in the future
+	sec %= 5000 * 365 * 24 * 60 * 60
+	*t = time.Unix(sec, nsec)
+}
+
+// Test 1000 iterations
+func TestFuzzCycle(t *testing.T) {
+	t.Skip("Skipped because of issue #65/66")
+	f := fuzz.New()
+	f.NumElements(0, 50)
+	f.NilChance(0.1)
+	f.Funcs(fuzzTime)
+
+	rFF := FfFuzz{}
+	r := Fuzz{}
+	for i := 0; i < 1000; i++ {
+		f.RandSource(rand.New(rand.NewSource(int64(i * 324221))))
+		f.Fuzz(&r)
+		rFF.A = r.A
+		rFF.B = r.B
+		rFF.C = r.C
+		rFF.D = r.D
+		rFF.E = r.E
+		rFF.F = r.F
+		rFF.G = r.G
+		rFF.H = r.H
+		rFF.I = r.I
+		rFF.J = r.J
+		rFF.M = r.M
+		rFF.N = r.N
+		rFF.O = r.O
+		rFF.P = r.P
+		rFF.Q = r.Q
+		rFF.R = r.R
+		rFF.S = r.S
+		rFF.U = r.U
+
+		rFF.Ap = r.Ap
+		rFF.Bp = r.Bp
+		rFF.Cp = r.Cp
+		rFF.Dp = r.Dp
+		rFF.Ep = r.Ep
+		rFF.Fp = r.Fp
+		rFF.Gp = r.Gp
+		rFF.Hp = r.Hp
+		rFF.Ip = r.Ip
+		rFF.Jp = r.Jp
+		rFF.Mp = r.Mp
+		rFF.Np = r.Np
+		rFF.Op = r.Op
+		rFF.Pp = r.Pp
+		rFF.Qp = r.Qp
+		rFF.Rp = r.Rp
+		rFF.Sp = r.Sp
+
+		rFF.Aa = r.Aa
+		rFF.Ba = r.Ba
+		rFF.Ca = r.Ca
+		rFF.Da = r.Da
+		rFF.Ea = r.Ea
+		rFF.Fa = r.Fa
+		rFF.Ga = r.Ga
+		rFF.Ha = r.Ha
+		rFF.Ia = r.Ia
+		rFF.Ja = r.Ja
+		rFF.Ma = r.Ma
+		rFF.Na = r.Na
+		rFF.Oa = r.Oa
+		rFF.Pa = r.Pa
+		rFF.Qa = r.Qa
+		rFF.Ra = r.Ra
+
+		rFF.Aap = r.Aap
+		rFF.Bap = r.Bap
+		rFF.Cap = r.Cap
+		rFF.Dap = r.Dap
+		rFF.Eap = r.Eap
+		rFF.Fap = r.Fap
+		rFF.Gap = r.Gap
+		rFF.Hap = r.Hap
+		rFF.Iap = r.Iap
+		rFF.Jap = r.Jap
+		rFF.Map = r.Map
+		rFF.Nap = r.Nap
+		rFF.Oap = r.Oap
+		rFF.Pap = r.Pap
+		rFF.Qap = r.Qap
+		rFF.Rap = r.Rap
+		testSameMarshal(t, &r, &rFF)
+		testCycle(t, &r, &rFF)
+	}
+}
+
+// Fuzz test for 1000 iterations
+func testTypeFuzz(t *testing.T, base interface{}, ff interface{}) {
+	require.Implements(t, (*json.Marshaler)(nil), ff)
+	require.Implements(t, (*json.Unmarshaler)(nil), ff)
+	require.Implements(t, (*marshalerFaster)(nil), ff)
+	require.Implements(t, (*unmarshalFaster)(nil), ff)
+
+	if _, ok := base.(unmarshalFaster); ok {
+		require.FailNow(t, "base should not have a UnmarshalJSONFFLexer")
+	}
+
+	if _, ok := base.(marshalerFaster); ok {
+		require.FailNow(t, "base should not have a MarshalJSONBuf")
+	}
+
+	f := fuzz.New()
+	f.NumElements(0, 50)
+	f.NilChance(0.1)
+	f.Funcs(fuzzTime)
+	for i := 0; i < 1000; i++ {
+		f.RandSource(rand.New(rand.NewSource(int64(i * 5275))))
+		f.Fuzz(base)
+		f.RandSource(rand.New(rand.NewSource(int64(i * 5275))))
+		f.Fuzz(ff)
+
+		testSameMarshal(t, base, ff)
+		testCycle(t, base, ff)
+	}
+}
+
+func TestFuzzArray(t *testing.T) {
+	testTypeFuzz(t, &Tarray{X: []int{}}, &Xarray{X: []int{}})
+}
+
+func TestFuzzArrayPtr(t *testing.T) {
+	testTypeFuzz(t, &TarrayPtr{X: []*int{}}, &XarrayPtr{X: []*int{}})
+}
+
+func TestFuzzTimeDuration(t *testing.T) {
+	testTypeFuzz(t, &Tduration{}, &Xduration{})
+}
+
+func TestFuzzBool(t *testing.T) {
+	testTypeFuzz(t, &Tbool{}, &Xbool{})
+}
+
+func TestFuzzInt(t *testing.T) {
+	testTypeFuzz(t, &Tint{}, &Xint{})
+}
+
+func TestFuzzByte(t *testing.T) {
+	t.Skip("Skipped because of issue #65")
+	testTypeFuzz(t, &Tbyte{}, &Xbyte{})
+}
+
+func TestFuzzInt8(t *testing.T) {
+	testTypeFuzz(t, &Tint8{}, &Xint8{})
+}
+
+func TestFuzzInt16(t *testing.T) {
+	testTypeFuzz(t, &Tint16{}, &Xint16{})
+}
+
+func TestFuzzInt32(t *testing.T) {
+	testTypeFuzz(t, &Tint32{}, &Xint32{})
+}
+
+func TestFuzzInt64(t *testing.T) {
+	testTypeFuzz(t, &Tint64{}, &Xint64{})
+}
+
+func TestFuzzUint(t *testing.T) {
+	testTypeFuzz(t, &Tuint{}, &Xuint{})
+}
+
+func TestFuzzUint8(t *testing.T) {
+	t.Skip("Skipped because of issue #65")
+	testTypeFuzz(t, &Tuint8{}, &Xuint8{})
+}
+
+func TestFuzzUint16(t *testing.T) {
+	testTypeFuzz(t, &Tuint16{}, &Xuint16{})
+}
+
+func TestFuzzUint32(t *testing.T) {
+	testTypeFuzz(t, &Tuint32{}, &Xuint32{})
+}
+
+func TestFuzzUint64(t *testing.T) {
+	testTypeFuzz(t, &Tuint64{}, &Xuint64{})
+}
+
+func TestFuzzUintptr(t *testing.T) {
+	testTypeFuzz(t, &Tuintptr{}, &Xuintptr{})
+}
+
+func TestFuzzFloat32(t *testing.T) {
+	testTypeFuzz(t, &Tfloat32{}, &Xfloat32{})
+}
+
+func TestFuzzFloat64(t *testing.T) {
+	testTypeFuzz(t, &Tfloat64{}, &Xfloat64{})
+}
+
+func TestFuzzString(t *testing.T) {
+	testTypeFuzz(t, &Tstring{}, &Xstring{})
+	testTypeFuzz(t, &Tmystring{}, &Xmystring{})
+	testTypeFuzz(t, &TmystringPtr{}, &XmystringPtr{})
+}
+
+func TestFuzzArrayTimeDuration(t *testing.T) {
+	t.Skip("Skipped because of issue #64")
+	//testTypeFuzz(t, &ATduration{}, &AXduration{})
+}
+
+func TestFuzzArrayBool(t *testing.T) {
+	testTypeFuzz(t, &ATbool{}, &AXbool{})
+}
+
+func TestFuzzArrayInt(t *testing.T) {
+	testTypeFuzz(t, &ATint{}, &AXint{})
+}
+
+func TestFuzzArrayByte(t *testing.T) {
+	t.Skip("Skipped because of issue #65")
+	testTypeFuzz(t, &ATbyte{}, &AXbyte{})
+}
+
+func TestFuzzArrayInt8(t *testing.T) {
+	testTypeFuzz(t, &ATint8{}, &AXint8{})
+}
+
+func TestFuzzArrayInt16(t *testing.T) {
+	testTypeFuzz(t, &ATint16{}, &AXint16{})
+}
+
+func TestFuzzArrayInt32(t *testing.T) {
+	testTypeFuzz(t, &ATint32{}, &AXint32{})
+}
+
+func TestFuzzArrayInt64(t *testing.T) {
+	testTypeFuzz(t, &ATint64{}, &AXint64{})
+}
+
+func TestFuzzArrayUint(t *testing.T) {
+	testTypeFuzz(t, &ATuint{}, &AXuint{})
+}
+
+func TestFuzzArrayUint8(t *testing.T) {
+	t.Skip("Skipped because of issue #65")
+	testTypeFuzz(t, &ATuint8{}, &AXuint8{})
+}
+
+func TestFuzzArrayUint16(t *testing.T) {
+	testTypeFuzz(t, &ATuint16{}, &AXuint16{})
+}
+
+func TestFuzzArrayUint32(t *testing.T) {
+	testTypeFuzz(t, &ATuint32{}, &AXuint32{})
+}
+
+func TestFuzzArrayUint64(t *testing.T) {
+	testTypeFuzz(t, &ATuint64{}, &AXuint64{})
+}
+
+func TestFuzzArrayUintptr(t *testing.T) {
+	testTypeFuzz(t, &ATuintptr{}, &AXuintptr{})
+}
+
+func TestFuzzArrayFloat32(t *testing.T) {
+	testTypeFuzz(t, &ATfloat32{}, &AXfloat32{})
+}
+
+func TestFuzzArrayFloat64(t *testing.T) {
+	testTypeFuzz(t, &ATfloat64{}, &AXfloat64{})
+}
+
+func TestFuzzArrayTime(t *testing.T) {
+	t.Skip("Skipped because of issue #64")
+	//testTypeFuzz(t, &ATtime{}, &AXtime{})
+}


### PR DESCRIPTION
* Uses github.com/google/gofuzz to generate (predictable) test data in structures.
* I have added standalone tests for the issues I have found.
* Tests 1000 random values per type. Values are the same between runs.
* This covers a lot more base types than before (array of X, array with pointer to x)

Tests that have open issues have been disabled.