### PR TITLE
Add map[string] code generation for marshall.

### DIFF
--- a/tests/ff.go
+++ b/tests/ff.go
@@ -711,3 +711,52 @@ type FfFuzz struct {
 	Qap []*string
 	Rap []*bool
 }
+
+// ffjson: skip
+type TTestMaps struct {
+	Aa map[string]uint8
+	Ba map[string]uint16
+	Ca map[string]uint32
+	Da map[string]uint64
+
+	Ea map[string]int8
+	Fa map[string]int16
+	Ga map[string]int32
+	Ha map[string]int64
+
+	Ia map[string]float32
+	Ja map[string]float64
+
+	Ma map[string]byte
+	Na map[string]rune
+
+	Oa map[string]int
+	Pa map[string]uint
+	Qa map[string]string
+	Ra map[string]bool
+
+	AaP map[string]*uint8
+	BaP map[string]*uint16
+	CaP map[string]*uint32
+	DaP map[string]*uint64
+
+	EaP map[string]*int8
+	FaP map[string]*int16
+	GaP map[string]*int32
+	HaP map[string]*int64
+
+	IaP map[string]*float32
+	JaP map[string]*float64
+
+	MaP map[string]*byte
+	NaP map[string]*rune
+
+	OaP map[string]*int
+	PaP map[string]*uint
+	QaP map[string]*string
+	RaP map[string]*bool
+}
+
+type XTestMaps struct {
+	TTestMaps
+}

--- a/tests/fuzz_test.go
+++ b/tests/fuzz_test.go
@@ -395,3 +395,37 @@ func TestFuzzArrayTime(t *testing.T) {
 	t.Skip("Skipped because of issue #64")
 	//testTypeFuzz(t, &ATtime{}, &AXtime{})
 }
+
+// This contains maps.
+// Since map order is random, we can expect the encoding order to be random
+// Therefore we cannot use binary compare.
+func TestFuzzMapToType(t *testing.T) {
+	base := &TTestMaps{}
+	ff := &XTestMaps{}
+	f := fuzz.New()
+	f.NumElements(0, 50)
+	f.NilChance(0.1)
+	f.Funcs(fuzzTime)
+	for i := 0; i < 100; i++ {
+		f.RandSource(rand.New(rand.NewSource(int64(i * 5275))))
+		f.Fuzz(base)
+		ff = &XTestMaps{*base}
+
+		bufbase, err := json.Marshal(base)
+		require.NoError(t, err, "base[%T] failed to Marshal", base)
+
+		bufff, err := json.Marshal(ff)
+		require.NoError(t, err, "ff[%T] failed to Marshal", ff)
+
+		var baseD map[string]interface{}
+		var ffD map[string]interface{}
+
+		err = json.Unmarshal(bufbase, &baseD)
+		require.NoError(t, err, "ff[%T] failed to Unmarshal", base)
+
+		err = json.Unmarshal(bufff, &ffD)
+		require.NoError(t, err, "ff[%T] failed to Unmarshal", ff)
+
+		require.Equal(t, baseD, ffD, "Inspected struct difference of base[%T] != ff[%T]", base, ff)
+	}
+}


### PR DESCRIPTION
Add code generation for map[string](simple-type like int, string) marshalling instead of using built-in.