### PR TITLE
Allow disabling encoder/decoder on all structs or by adding comment to struct

### DIFF
--- a/generator/inceptionmain.go
+++ b/generator/inceptionmain.go
@@ -56,17 +56,26 @@ const ffjsonExposeTemplate = `
 
 package {{.PackageName}}
 
-func FFJSONExpose() []interface{} {
-	rv := make([]interface{}, 0)
+import (
+	ffjsonshared "github.com/pquerna/ffjson/shared"
+)
+
+func FFJSONExpose() []ffjsonshared.InceptionType {
+	rv := make([]ffjsonshared.InceptionType, 0)
 {{range .StructNames}}
-	rv = append(rv, {{.}}{})
+	rv = append(rv, ffjsonshared.InceptionType{Obj: {{.Name}}{}, Options: ffjson{{printf "%#v" .Options}} } )
 {{end}}
 	return rv
 }
 `
 
+type structName struct {
+	Name    string
+	Options shared.StructOptions
+}
+
 type templateCtx struct {
-	StructNames []string
+	StructNames []structName
 	ImportName  string
 	PackageName string
 	InputPath   string
@@ -172,9 +181,10 @@ func (im *InceptionMain) Generate(packageName string, si []*StructInfo) error {
 	}
 
 	im.TempMainPath = im.tempMain.Name()
-	sn := make([]string, 0)
-	for _, st := range si {
-		sn = append(sn, st.Name)
+	sn := make([]structName, len(si))
+	for i, st := range si {
+		sn[i].Name = st.Name
+		sn[i].Options = st.Options
 	}
 
 	tc := &templateCtx{

--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -373,8 +373,6 @@ func CreateMarshalJSON(ic *Inception, si *StructInfo) error {
 	needScratch := false
 	out := ""
 
-	ic.OutputImports[`"bytes"`] = true
-
 	out += `func (mj *` + si.Name + `) MarshalJSON() ([]byte, error) {` + "\n"
 	out += `var buf fflib.Buffer` + "\n"
 

--- a/inception/inception.go
+++ b/inception/inception.go
@@ -20,6 +20,7 @@ package ffjsoninception
 import (
 	"errors"
 	"fmt"
+	"github.com/pquerna/ffjson/shared"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -48,18 +49,21 @@ func NewInception(inputPath string, packageName string, outputPath string) *Ince
 	}
 }
 
-func (i *Inception) AddMany(objs []interface{}) {
+func (i *Inception) AddMany(objs []shared.InceptionType) {
 	for _, obj := range objs {
 		i.Add(obj)
 	}
 }
 
-func (i *Inception) Add(obj interface{}) {
+func (i *Inception) Add(obj shared.InceptionType) {
 	i.objs = append(i.objs, NewStructInfo(obj))
 	i.PackagePath = i.objs[0].Typ.PkgPath()
 }
 
 func (i *Inception) wantUnmarshal(si *StructInfo) bool {
+	if si.Options.SkipDecoder {
+		return false
+	}
 	typ := si.Typ
 	umlx := typ.Implements(unmarshalFasterType) || reflect.PtrTo(typ).Implements(unmarshalFasterType)
 	umlstd := typ.Implements(unmarshalerType) || reflect.PtrTo(typ).Implements(unmarshalerType)
@@ -71,6 +75,9 @@ func (i *Inception) wantUnmarshal(si *StructInfo) bool {
 }
 
 func (i *Inception) wantMarshal(si *StructInfo) bool {
+	if si.Options.SkipEncoder {
+		return false
+	}
 	typ := si.Typ
 	mlx := typ.Implements(marshalerFasterType) || reflect.PtrTo(typ).Implements(marshalerFasterType)
 	mlstd := typ.Implements(marshalerType) || reflect.PtrTo(typ).Implements(marshalerType)

--- a/inception/reflect.go
+++ b/inception/reflect.go
@@ -19,6 +19,7 @@ package ffjsoninception
 
 import (
 	fflib "github.com/pquerna/ffjson/fflib/v1"
+	"github.com/pquerna/ffjson/shared"
 
 	"bytes"
 	"encoding/json"
@@ -44,19 +45,21 @@ func (a FieldByJsonName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a FieldByJsonName) Less(i, j int) bool { return a[i].JsonName < a[j].JsonName }
 
 type StructInfo struct {
-	Name   string
-	Obj    interface{}
-	Typ    reflect.Type
-	Fields []*StructField
+	Name    string
+	Obj     interface{}
+	Typ     reflect.Type
+	Fields  []*StructField
+	Options shared.StructOptions
 }
 
-func NewStructInfo(obj interface{}) *StructInfo {
-	t := reflect.TypeOf(obj)
+func NewStructInfo(obj shared.InceptionType) *StructInfo {
+	t := reflect.TypeOf(obj.Obj)
 	return &StructInfo{
-		Obj:    obj,
-		Name:   t.Name(),
-		Typ:    t,
-		Fields: extractFields(obj),
+		Obj:     obj.Obj,
+		Name:    t.Name(),
+		Typ:     t,
+		Fields:  extractFields(obj.Obj),
+		Options: obj.Options,
 	}
 }
 

--- a/shared/options.go
+++ b/shared/options.go
@@ -1,0 +1,28 @@
+/**
+ *  Copyright 2014 Paul Querna, Klaus Post
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package shared
+
+type StructOptions struct {
+	SkipDecoder bool
+	SkipEncoder bool
+}
+
+type InceptionType struct {
+	Obj     interface{}
+	Options StructOptions
+}

--- a/tests/ff.go
+++ b/tests/ff.go
@@ -757,3 +757,15 @@ type TTestMaps struct {
 type XTestMaps struct {
 	TTestMaps
 }
+
+// ffjson: noencoder
+type NoEncoder struct {
+	C string
+	B int `json:"A"`
+}
+
+// ffjson: nodecoder
+type NoDecoder struct {
+	C string
+	B int `json:"A"`
+}

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -504,3 +504,17 @@ func TestArrayFloat64(t *testing.T) {
 func TestArrayTime(t *testing.T) {
 	testType(t, &ATtime{}, &AXtime{})
 }
+
+func TestNoDecoder(t *testing.T) {
+	var test interface{} = &NoDecoder{}
+	if _, ok := test.(unmarshalFaster); ok {
+		require.FailNow(t, "NoDecoder should not have a UnmarshalJSONFFLexer")
+	}
+}
+
+func TestNoEncoder(t *testing.T) {
+	var test interface{} = &NoEncoder{}
+	if _, ok := test.(marshalerFaster); ok {
+		require.FailNow(t, "NoEncoder should not have a MarshalJSONBuf")
+	}
+}


### PR DESCRIPTION
This pathch adds //ffjson: nodecoder and //ffjson: noencoder as well as commandline options to disable generation of en/decoder. Fixes issue #43 

Commandline options are defaults, and struct comments allow to further disable parts of the generation.