### PR TITLE
Use format 'g' for strconv.FormatFloat

### DIFF
--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -177,10 +177,10 @@ func getGetInnerValue(ic *Inception, name string, typ reflect.Type, ptr bool, fo
 		out += "fflib.FormatBits(&scratch, buf, uint64(" + ptname + "), 10, false)" + "\n"
 	case reflect.Float32:
 		ic.OutputImports[`"strconv"`] = true
-		out += "buf.Write(strconv.AppendFloat([]byte{}, float64(" + ptname + "), 'f', -1, 32))" + "\n"
+		out += "buf.Write(strconv.AppendFloat([]byte{}, float64(" + ptname + "), 'g', -1, 32))" + "\n"
 	case reflect.Float64:
 		ic.OutputImports[`"strconv"`] = true
-		out += "buf.Write(strconv.AppendFloat([]byte{}, " + ptname + ", 'f', -1, 64))" + "\n"
+		out += "buf.Write(strconv.AppendFloat([]byte{}, " + ptname + ", 'g', -1, 64))" + "\n"
 	case reflect.Array,
 		reflect.Slice:
 

--- a/tests/ff.go
+++ b/tests/ff.go
@@ -642,7 +642,6 @@ type FfFuzz struct {
 	Q string
 	R bool
 	S time.Time
-	U map[string]string
 
 	Ap *uint8
 	Bp *uint16

--- a/tests/fuzz_test.go
+++ b/tests/fuzz_test.go
@@ -48,7 +48,6 @@ type Fuzz struct {
 	Q string
 	R bool
 	S time.Time
-	U map[string]string
 
 	Ap *uint8
 	Bp *uint16
@@ -139,7 +138,6 @@ func fuzzTimeArray(t *[]time.Time, c fuzz.Continue) {
 
 // Test 1000 iterations
 func TestFuzzCycle(t *testing.T) {
-	t.Skip("Skipped because of issue #66")
 	f := fuzz.New()
 	f.NumElements(0, 50)
 	f.NilChance(0.1)
@@ -167,7 +165,6 @@ func TestFuzzCycle(t *testing.T) {
 		rFF.Q = r.Q
 		rFF.R = r.R
 		rFF.S = r.S
-		rFF.U = r.U
 
 		rFF.Ap = r.Ap
 		rFF.Bp = r.Bp


### PR DESCRIPTION
See [encode.go](http://golang.org/src/encoding/json/encode.go#L512)

We should do the same. 

Disabling map in big fuzz test (map order is random, so encoding output cannot be compared) - that makes it complete.