### PR TITLE
Allow buffer reuse for less GC stress

### DIFF
--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -166,7 +166,7 @@ func getGetInnerValue(ic *Inception, name string, typ reflect.Type, ptr bool, fo
 		reflect.Int32,
 		reflect.Int64:
 		ic.OutputImports[`fflib "github.com/pquerna/ffjson/fflib/v1"`] = true
-		out += "fflib.FormatBits(&scratch, buf, uint64(" + ptname + "), 10, " + ptname + " < 0)" + "\n"
+		out += "fflib.FormatBits(nil, buf, uint64(" + ptname + "), 10, " + ptname + " < 0)" + "\n"
 	case reflect.Uint,
 		reflect.Uint8,
 		reflect.Uint16,
@@ -174,7 +174,7 @@ func getGetInnerValue(ic *Inception, name string, typ reflect.Type, ptr bool, fo
 		reflect.Uint64,
 		reflect.Uintptr:
 		ic.OutputImports[`fflib "github.com/pquerna/ffjson/fflib/v1"`] = true
-		out += "fflib.FormatBits(&scratch, buf, uint64(" + ptname + "), 10, false)" + "\n"
+		out += "fflib.FormatBits(nil, buf, uint64(" + ptname + "), 10, false)" + "\n"
 	case reflect.Float32:
 		ic.OutputImports[`"strconv"`] = true
 		out += "buf.Write(strconv.AppendFloat([]byte{}, float64(" + ptname + "), 'f', -1, 32))" + "\n"
@@ -370,7 +370,6 @@ func isIntish(t reflect.Type) bool {
 
 func CreateMarshalJSON(ic *Inception, si *StructInfo) error {
 	conditionalWrites := false
-	needScratch := false
 	out := ""
 
 	ic.OutputImports[`"bytes"`] = true
@@ -386,17 +385,6 @@ func CreateMarshalJSON(ic *Inception, si *StructInfo) error {
 	out += `return buf.Bytes(), nil` + "\n"
 	out += `}` + "\n"
 
-	for _, f := range si.Fields {
-		if isIntish(f.Typ) {
-			needScratch = true
-		}
-		if f.Typ.Kind() == reflect.Map {
-			if isIntish(f.Typ.Elem()) {
-				needScratch = true
-			}
-		}
-	}
-
 	// We check if the last field is conditional.
 	if len(si.Fields) > 0 {
 		f := si.Fields[len(si.Fields)-1]
@@ -406,10 +394,6 @@ func CreateMarshalJSON(ic *Inception, si *StructInfo) error {
 	out += `func (mj *` + si.Name + `) MarshalJSONBuf(buf fflib.EncodingBuffer) (error) {` + "\n"
 	out += `var err error` + "\n"
 	out += `var obj []byte` + "\n"
-	if needScratch {
-		out += `var scratch fflib.FormatBitsScratch` + "\n"
-		out += `_ = scratch` + "\n"
-	}
 
 	out += `_ = obj` + "\n"
 	out += `_ = err` + "\n"

--- a/tests/bench.cmd
+++ b/tests/bench.cmd
@@ -1,5 +1,8 @@
 del ff_ffjson.go
 ffjson ff.go
 
-go test -benchmem -bench MarshalJSON
-go test -benchmem -bench MarshalJSONNative -cpuprofile="prof.dat" -benchtime 10s &&go tool pprof -gif tests.test.exe prof.dat >out.gif
+go test -benchmem -test.run="Nothing" -bench MarshalJSON
+go test -benchmem -test.run="Nothing" -test.bench="MarshalJSONNative" -cpuprofile="prof.dat" -benchtime 10s &&go tool pprof -gif tests.test.exe prof.dat >cpu.gif
+go test -benchmem -test.run="Nothing" -test.bench="MarshalJSONNativeReuse" -memprofile="prof.dat" -test.memprofilerate=1 -benchtime 10s &&go tool pprof -lines -alloc_objects -gif tests.test.exe prof.dat  >mem-reuse.gif
+
+go test -benchmem -test.run="Nothing" -test.bench="MarshalJSONNativePool" -memprofile="prof.dat" -test.memprofilerate=1 -benchtime 10s &&go tool pprof -lines -alloc_objects -gif tests.test.exe prof.dat  >mem-pool.gif

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -81,6 +81,25 @@ func BenchmarkMarshalJSONNative(b *testing.B) {
 	}
 }
 
+func BenchmarkMarshalJSONNativePool(b *testing.B) {
+	record := newLogFFRecord()
+
+	buf, err := json.Marshal(&record)
+	if err != nil {
+		b.Fatalf("Marshal: %v", err)
+	}
+	b.SetBytes(int64(len(buf)))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bytes, err := record.MarshalJSON()
+		if err != nil {
+			b.Fatalf("Marshal: %v", err)
+		}
+		fflib.Pool(bytes)
+	}
+}
+
 func BenchmarkMarshalJSONNativeReuse(b *testing.B) {
 	record := newLogFFRecord()
 

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -102,7 +102,6 @@ func BenchmarkMarshalJSONNativePool(b *testing.B) {
 
 func BenchmarkMarshalJSONNativeReuse(b *testing.B) {
 	record := newLogFFRecord()
-
 	buf, err := json.Marshal(&record)
 	if err != nil {
 		b.Fatalf("Marshal: %v", err)
@@ -113,10 +112,6 @@ func BenchmarkMarshalJSONNativeReuse(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		err := record.MarshalJSONBuf(&buffer)
-		if err != nil {
-			b.Fatalf("Marshal: %v", err)
-		}
-		buffer.Reset()
 		if err != nil {
 			b.Fatalf("Marshal: %v", err)
 		}

--- a/tests/t.cmd
+++ b/tests/t.cmd
@@ -1,2 +1,3 @@
+go install github.com/pquerna/ffjson
 del ff_ffjson.go
 go test -v github.com/pquerna/ffjson/fflib/v1 github.com/pquerna/ffjson/generator github.com/pquerna/ffjson/inception && ffjson ff.go && go test -v


### PR DESCRIPTION
With this addition there is now two ways to reuse the buffer.

1) Reuse the fflib.Buffer and use the custom encoding. Good for file encoding, etc.
2) Handing back the byte array after you have finished using it by useing fflib.Pool(bytes). good for webservers where everything is in separate goroutines.

Note that fflib will now require Go 1.3+

Benchmarks on a complex data structure:

```
enconding/json:	     		37964 ns/op	  34.90 MB/s	    6088 B/op	      27 allocs/op
ffjson/bare	     			17307 ns/op	  76.56 MB/s	    3035 B/op	      24 allocs/op
ffjson/pool	    			13231 ns/op	 100.14 MB/s	     664 B/op	      22 allocs/op
ffjson/reuse-buffer	    	12716 ns/op	 104.19 MB/s	     584 B/op	      20 allocs/op
```