### PR TITLE
support import name override

### DIFF
--- a/ffjson.go
+++ b/ffjson.go
@@ -31,6 +31,7 @@ import (
 
 var outputPathFlag = flag.String("w", "", "Write generate code to this path instead of ${input}_ffjson.go.")
 var goCmdFlag = flag.String("go-cmd", "", "Path to go command; Useful for `goapp` support.")
+var importNameFlag = flag.String("import-name", "", "Override import name in case it cannot be detected.")
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n\n", os.Args[0])
@@ -66,7 +67,12 @@ func main() {
 		goCmd = *goCmdFlag
 	}
 
-	err := generator.GenerateFiles(goCmd, inputPath, outputPath)
+	var importName string
+	if importNameFlag != nil && *importNameFlag != "" {
+		importName = *importNameFlag
+	}
+
+	err := generator.GenerateFiles(goCmd, inputPath, outputPath, importName)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s:\n\n", err)

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 )
 
-func GenerateFiles(goCmd string, inputPath string, outputPath string) error {
+func GenerateFiles(goCmd string, inputPath string, outputPath string, importName string) error {
 	packageName, structs, err := ExtractStructs(inputPath)
 	if err != nil {
 		return err
@@ -30,7 +30,7 @@ func GenerateFiles(goCmd string, inputPath string, outputPath string) error {
 
 	im := NewInceptionMain(goCmd, inputPath, outputPath)
 
-	err = im.Generate(packageName, structs)
+	err = im.Generate(packageName, structs, importName)
 	if err != nil {
 		return errors.New(fmt.Sprintf("error=%v path=%q", err, im.TempMainPath))
 	}

--- a/generator/inceptionmain.go
+++ b/generator/inceptionmain.go
@@ -165,13 +165,11 @@ func (im *InceptionMain) renderTpl(f *os.File, t *template.Template, tc *templat
 	return nil
 }
 
-func (im *InceptionMain) Generate(packageName string, si []*StructInfo) error {
+func (im *InceptionMain) Generate(packageName string, si []*StructInfo, importName string) error {
 	var err error
-	var importName string
 
-	if importName = os.Getenv("FFJSON_IMPORT_NAME"); importName == "" {
+	if importName == "" {
 		importName, err = getImportName(im.inputPath)
-
 		if err != nil {
 			return err
 		}

--- a/generator/inceptionmain.go
+++ b/generator/inceptionmain.go
@@ -21,12 +21,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/pquerna/ffjson/shared"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/pquerna/ffjson/shared"
 )
 
 const inceptionMainTemplate = `
@@ -166,11 +167,14 @@ func (im *InceptionMain) renderTpl(f *os.File, t *template.Template, tc *templat
 
 func (im *InceptionMain) Generate(packageName string, si []*StructInfo) error {
 	var err error
+	var importName string
 
-	importName, err := getImportName(im.inputPath)
+	if importName = os.Getenv("FFJSON_IMPORT_NAME"); importName == "" {
+		importName, err = getImportName(im.inputPath)
 
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	importName = filepath.ToSlash(importName)


### PR DESCRIPTION
under some circumstances (e.g. while using goop) the import name detection fails, so we simply pass it via the environment from our makefile. this patch adds support for this env variable.