### PR TITLE
add comma only if field is non-empty

### DIFF
--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -451,10 +451,10 @@ func CreateMarshalJSON(ic *Inception, si *StructInfo) error {
 		}
 
 		if f.OmitEmpty {
+			out += ic.q.Flush()
 			if f.Pointer {
 				out += "}" + "\n"
 			}
-			out += ic.q.Flush()
 			out += "}" + "\n"
 		}
 	}


### PR DESCRIPTION
i found this during upgrading to latest master. omitempty pointer fields that are non-nil but empty produce stray commas in the generated json. i'm not 100% sure this is the correct fix, but it made all our use cases work and tests are still green.