### PR TITLE
Add tests for string and omitempty tags, and fix issues found

### DIFF
--- a/tests/ff.go
+++ b/tests/ff.go
@@ -722,6 +722,284 @@ type FfFuzz struct {
 }
 
 // ffjson: skip
+type FuzzOmitEmpty struct {
+	A uint8  `json:",omitempty"`
+	B uint16 `json:",omitempty"`
+	C uint32 `json:",omitempty"`
+	D uint64 `json:",omitempty"`
+
+	E int8  `json:",omitempty"`
+	F int16 `json:",omitempty"`
+	G int32 `json:",omitempty"`
+	H int64 `json:",omitempty"`
+
+	I float32 `json:",omitempty"`
+	J float64 `json:",omitempty"`
+
+	M byte `json:",omitempty"`
+	N rune `json:",omitempty"`
+
+	O int       `json:",omitempty"`
+	P uint      `json:",omitempty"`
+	Q string    `json:",omitempty"`
+	R bool      `json:",omitempty"`
+	S time.Time `json:",omitempty"`
+
+	Ap *uint8  `json:",omitempty"`
+	Bp *uint16 `json:",omitempty"`
+	Cp *uint32 `json:",omitempty"`
+	Dp *uint64 `json:",omitempty"`
+
+	Ep *int8  `json:",omitempty"`
+	Fp *int16 `json:",omitempty"`
+	Gp *int32 `json:",omitempty"`
+	Hp *int64 `json:",omitempty"`
+
+	Ip *float32 `json:",omitempty"`
+	Jp *float64 `json:",omitempty"`
+
+	Mp *byte `json:",omitempty"`
+	Np *rune `json:",omitempty"`
+
+	Op *int       `json:",omitempty"`
+	Pp *uint      `json:",omitempty"`
+	Qp *string    `json:",omitempty"`
+	Rp *bool      `json:",omitempty"`
+	Sp *time.Time `json:",omitempty"`
+
+	Aa []uint8  `json:",omitempty"`
+	Ba []uint16 `json:",omitempty"`
+	Ca []uint32 `json:",omitempty"`
+	Da []uint64 `json:",omitempty"`
+
+	Ea []int8  `json:",omitempty"`
+	Fa []int16 `json:",omitempty"`
+	Ga []int32 `json:",omitempty"`
+	Ha []int64 `json:",omitempty"`
+
+	Ia []float32 `json:",omitempty"`
+	Ja []float64 `json:",omitempty"`
+
+	Ma []byte `json:",omitempty"`
+	Na []rune `json:",omitempty"`
+
+	Oa []int    `json:",omitempty"`
+	Pa []uint   `json:",omitempty"`
+	Qa []string `json:",omitempty"`
+	Ra []bool   `json:",omitempty"`
+
+	Aap []*uint8  `json:",omitempty"`
+	Bap []*uint16 `json:",omitempty"`
+	Cap []*uint32 `json:",omitempty"`
+	Dap []*uint64 `json:",omitempty"`
+
+	Eap []*int8  `json:",omitempty"`
+	Fap []*int16 `json:",omitempty"`
+	Gap []*int32 `json:",omitempty"`
+	Hap []*int64 `json:",omitempty"`
+
+	Iap []*float32 `json:",omitempty"`
+	Jap []*float64 `json:",omitempty"`
+
+	Map []*byte `json:",omitempty"`
+	Nap []*rune `json:",omitempty"`
+
+	Oap []*int    `json:",omitempty"`
+	Pap []*uint   `json:",omitempty"`
+	Qap []*string `json:",omitempty"`
+	Rap []*bool   `json:",omitempty"`
+}
+
+type FfFuzzOmitEmpty struct {
+	A uint8  `json:",omitempty"`
+	B uint16 `json:",omitempty"`
+	C uint32 `json:",omitempty"`
+	D uint64 `json:",omitempty"`
+
+	E int8  `json:",omitempty"`
+	F int16 `json:",omitempty"`
+	G int32 `json:",omitempty"`
+	H int64 `json:",omitempty"`
+
+	I float32 `json:",omitempty"`
+	J float64 `json:",omitempty"`
+
+	M byte `json:",omitempty"`
+	N rune `json:",omitempty"`
+
+	O int       `json:",omitempty"`
+	P uint      `json:",omitempty"`
+	Q string    `json:",omitempty"`
+	R bool      `json:",omitempty"`
+	S time.Time `json:",omitempty"`
+
+	Ap *uint8  `json:",omitempty"`
+	Bp *uint16 `json:",omitempty"`
+	Cp *uint32 `json:",omitempty"`
+	Dp *uint64 `json:",omitempty"`
+
+	Ep *int8  `json:",omitempty"`
+	Fp *int16 `json:",omitempty"`
+	Gp *int32 `json:",omitempty"`
+	Hp *int64 `json:",omitempty"`
+
+	Ip *float32 `json:",omitempty"`
+	Jp *float64 `json:",omitempty"`
+
+	Mp *byte `json:",omitempty"`
+	Np *rune `json:",omitempty"`
+
+	Op *int       `json:",omitempty"`
+	Pp *uint      `json:",omitempty"`
+	Qp *string    `json:",omitempty"`
+	Rp *bool      `json:",omitempty"`
+	Sp *time.Time `json:",omitempty"`
+
+	Aa []uint8  `json:",omitempty"`
+	Ba []uint16 `json:",omitempty"`
+	Ca []uint32 `json:",omitempty"`
+	Da []uint64 `json:",omitempty"`
+
+	Ea []int8  `json:",omitempty"`
+	Fa []int16 `json:",omitempty"`
+	Ga []int32 `json:",omitempty"`
+	Ha []int64 `json:",omitempty"`
+
+	Ia []float32 `json:",omitempty"`
+	Ja []float64 `json:",omitempty"`
+
+	Ma []byte `json:",omitempty"`
+	Na []rune `json:",omitempty"`
+
+	Oa []int    `json:",omitempty"`
+	Pa []uint   `json:",omitempty"`
+	Qa []string `json:",omitempty"`
+	Ra []bool   `json:",omitempty"`
+
+	Aap []*uint8  `json:",omitempty"`
+	Bap []*uint16 `json:",omitempty"`
+	Cap []*uint32 `json:",omitempty"`
+	Dap []*uint64 `json:",omitempty"`
+
+	Eap []*int8  `json:",omitempty"`
+	Fap []*int16 `json:",omitempty"`
+	Gap []*int32 `json:",omitempty"`
+	Hap []*int64 `json:",omitempty"`
+
+	Iap []*float32 `json:",omitempty"`
+	Jap []*float64 `json:",omitempty"`
+
+	Map []*byte `json:",omitempty"`
+	Nap []*rune `json:",omitempty"`
+
+	Oap []*int    `json:",omitempty"`
+	Pap []*uint   `json:",omitempty"`
+	Qap []*string `json:",omitempty"`
+	Rap []*bool   `json:",omitempty"`
+}
+
+// ffjson: skip
+type FuzzString struct {
+	A uint8  `json:",string"`
+	B uint16 `json:",string"`
+	C uint32 `json:",string"`
+	D uint64 `json:",string"`
+
+	E int8  `json:",string"`
+	F int16 `json:",string"`
+	G int32 `json:",string"`
+	H int64 `json:",string"`
+
+	I float32 `json:",string"`
+	J float64 `json:",string"`
+
+	M byte `json:",string"`
+	N rune `json:",string"`
+
+	O int  `json:",string"`
+	P uint `json:",string"`
+
+	Q string `json:",string"`
+
+	R bool `json:",string"`
+	// https://github.com/golang/go/issues/9812
+	// S time.Time `json:",string"`
+
+	Ap *uint8  `json:",string"`
+	Bp *uint16 `json:",string"`
+	Cp *uint32 `json:",string"`
+	Dp *uint64 `json:",string"`
+
+	Ep *int8  `json:",string"`
+	Fp *int16 `json:",string"`
+	Gp *int32 `json:",string"`
+	Hp *int64 `json:",string"`
+
+	Ip *float32 `json:",string"`
+	Jp *float64 `json:",string"`
+
+	Mp *byte `json:",string"`
+	Np *rune `json:",string"`
+
+	Op *int    `json:",string"`
+	Pp *uint   `json:",string"`
+	Qp *string `json:",string"`
+	Rp *bool   `json:",string"`
+	// https://github.com/golang/go/issues/9812
+	// Sp *time.Time `json:",string"`
+}
+
+type FfFuzzString struct {
+	A uint8  `json:",string"`
+	B uint16 `json:",string"`
+	C uint32 `json:",string"`
+	D uint64 `json:",string"`
+
+	E int8  `json:",string"`
+	F int16 `json:",string"`
+	G int32 `json:",string"`
+	H int64 `json:",string"`
+
+	I float32 `json:",string"`
+	J float64 `json:",string"`
+
+	M byte `json:",string"`
+	N rune `json:",string"`
+
+	O int  `json:",string"`
+	P uint `json:",string"`
+
+	Q string `json:",string"`
+
+	R bool `json:",string"`
+	// https://github.com/golang/go/issues/9812
+	// S time.Time `json:",string"`
+
+	Ap *uint8  `json:",string"`
+	Bp *uint16 `json:",string"`
+	Cp *uint32 `json:",string"`
+	Dp *uint64 `json:",string"`
+
+	Ep *int8  `json:",string"`
+	Fp *int16 `json:",string"`
+	Gp *int32 `json:",string"`
+	Hp *int64 `json:",string"`
+
+	Ip *float32 `json:",string"`
+	Jp *float64 `json:",string"`
+
+	Mp *byte `json:",string"`
+	Np *rune `json:",string"`
+
+	Op *int    `json:",string"`
+	Pp *uint   `json:",string"`
+	Qp *string `json:",string"`
+	Rp *bool   `json:",string"`
+	// https://github.com/golang/go/issues/9812
+	// Sp *time.Time `json:",string"`
+}
+
+// ffjson: skip
 type TTestMaps struct {
 	Aa map[string]uint8
 	Ba map[string]uint16

--- a/tests/fuzz_test.go
+++ b/tests/fuzz_test.go
@@ -22,6 +22,8 @@ import (
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/require"
 	"math/rand"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -316,6 +318,10 @@ func TestFuzzOmitCycle(t *testing.T) {
 
 // Test 1000 iterations
 func TestFuzzStringCycle(t *testing.T) {
+	ver := runtime.Version()
+	if strings.Contains(ver, "go1.3") || strings.Contains(ver, "go1.2") {
+		t.Skipf("Test requires go v1.4 or later, this is %s", ver)
+	}
 	f := fuzz.New()
 	f.NumElements(0, 50)
 	f.NilChance(0.1)

--- a/tests/fuzz_test.go
+++ b/tests/fuzz_test.go
@@ -146,8 +146,12 @@ func TestFuzzCycle(t *testing.T) {
 	rFF := FfFuzz{}
 	r := Fuzz{}
 	for i := 0; i < 1000; i++ {
-		f.RandSource(rand.New(rand.NewSource(int64(i * 324221))))
-		f.Fuzz(&r)
+		if true || i > 0 {
+			// TODO: Re-enable after fixing:
+			// https://github.com/pquerna/ffjson/issues/82
+			f.RandSource(rand.New(rand.NewSource(int64(i * 324221))))
+			f.Fuzz(&r)
+		}
 		rFF.A = r.A
 		rFF.B = r.B
 		rFF.C = r.C
@@ -219,6 +223,156 @@ func TestFuzzCycle(t *testing.T) {
 		rFF.Rap = r.Rap
 		testSameMarshal(t, &r, &rFF)
 		testCycle(t, &r, &rFF)
+	}
+}
+
+// Test 1000 iterations
+func TestFuzzOmitCycle(t *testing.T) {
+	f := fuzz.New()
+	f.NumElements(0, 10)
+	f.NilChance(0.5)
+	f.Funcs(fuzzTime)
+
+	rFF := FfFuzzOmitEmpty{}
+	r := FuzzOmitEmpty{}
+	for i := 0; i <= 1000; i++ {
+		if i > 0 {
+			f.RandSource(rand.New(rand.NewSource(int64(i * 324221))))
+			f.Fuzz(&r)
+		}
+		rFF.A = r.A
+		rFF.B = r.B
+		rFF.C = r.C
+		rFF.D = r.D
+		rFF.E = r.E
+		rFF.F = r.F
+		rFF.G = r.G
+		rFF.H = r.H
+		rFF.I = r.I
+		rFF.J = r.J
+		rFF.M = r.M
+		rFF.N = r.N
+		rFF.O = r.O
+		rFF.P = r.P
+		rFF.Q = r.Q
+		rFF.R = r.R
+		rFF.S = r.S
+
+		rFF.Ap = r.Ap
+		rFF.Bp = r.Bp
+		rFF.Cp = r.Cp
+		rFF.Dp = r.Dp
+		rFF.Ep = r.Ep
+		rFF.Fp = r.Fp
+		rFF.Gp = r.Gp
+		rFF.Hp = r.Hp
+		rFF.Ip = r.Ip
+		rFF.Jp = r.Jp
+		rFF.Mp = r.Mp
+		rFF.Np = r.Np
+		rFF.Op = r.Op
+		rFF.Pp = r.Pp
+		rFF.Qp = r.Qp
+		rFF.Rp = r.Rp
+		rFF.Sp = r.Sp
+
+		rFF.Aa = r.Aa
+		rFF.Ba = r.Ba
+		rFF.Ca = r.Ca
+		rFF.Da = r.Da
+		rFF.Ea = r.Ea
+		rFF.Fa = r.Fa
+		rFF.Ga = r.Ga
+		rFF.Ha = r.Ha
+		rFF.Ia = r.Ia
+		rFF.Ja = r.Ja
+		rFF.Ma = r.Ma
+		rFF.Na = r.Na
+		rFF.Oa = r.Oa
+		rFF.Pa = r.Pa
+		rFF.Qa = r.Qa
+		rFF.Ra = r.Ra
+
+		rFF.Aap = r.Aap
+		rFF.Bap = r.Bap
+		rFF.Cap = r.Cap
+		rFF.Dap = r.Dap
+		rFF.Eap = r.Eap
+		rFF.Fap = r.Fap
+		rFF.Gap = r.Gap
+		rFF.Hap = r.Hap
+		rFF.Iap = r.Iap
+		rFF.Jap = r.Jap
+		rFF.Map = r.Map
+		rFF.Nap = r.Nap
+		rFF.Oap = r.Oap
+		rFF.Pap = r.Pap
+		rFF.Qap = r.Qap
+		rFF.Rap = r.Rap
+		testSameMarshal(t, &r, &rFF)
+		testCycle(t, &r, &rFF)
+	}
+}
+
+// Test 1000 iterations
+func TestFuzzStringCycle(t *testing.T) {
+	f := fuzz.New()
+	f.NumElements(0, 50)
+	f.NilChance(0.1)
+	f.Funcs(fuzzTime)
+
+	rFF := FfFuzzString{}
+	r := FuzzString{}
+	for i := 0; i < 1000; i++ {
+		if i > 0 {
+			f.RandSource(rand.New(rand.NewSource(int64(i * 324221))))
+			f.Fuzz(&r)
+		}
+		rFF.A = r.A
+		rFF.B = r.B
+		rFF.C = r.C
+		rFF.D = r.D
+		rFF.E = r.E
+		rFF.F = r.F
+		rFF.G = r.G
+		rFF.H = r.H
+		rFF.I = r.I
+		rFF.J = r.J
+		rFF.M = r.M
+		rFF.N = r.N
+		rFF.O = r.O
+		rFF.P = r.P
+		rFF.Q = r.Q
+		rFF.R = r.R
+
+		// https://github.com/golang/go/issues/9812
+		// rFF.S = r.S
+
+		rFF.Ap = r.Ap
+		rFF.Bp = r.Bp
+		rFF.Cp = r.Cp
+		rFF.Dp = r.Dp
+		rFF.Ep = r.Ep
+		rFF.Fp = r.Fp
+		rFF.Gp = r.Gp
+		rFF.Hp = r.Hp
+		rFF.Ip = r.Ip
+		rFF.Jp = r.Jp
+		rFF.Mp = r.Mp
+		rFF.Np = r.Np
+		rFF.Op = r.Op
+		rFF.Pp = r.Pp
+		rFF.Qp = r.Qp
+		rFF.Rp = r.Rp
+		// https://github.com/golang/go/issues/9812
+		// rFF.Sp = r.Sp
+
+		// The "string" option signals that a field is stored as JSON inside a JSON-encoded string. It applies only to fields of string, floating point, or integer types. This extra level of encoding is sometimes used when communicating with JavaScript programs.
+		// Therefore tests on byte arrays are removed, since the golang decoder chokes on them.
+		testSameMarshal(t, &r, &rFF)
+
+		// Disabled: https://github.com/pquerna/ffjson/issues/80
+		// testCycle(t, &r, &rFF)
 	}
 }
 


### PR DESCRIPTION
This fixes:

* https://github.com/pquerna/ffjson/issues/76  (Omitempty on pointer to value should only omit if not nil)
* https://github.com/pquerna/ffjson/issues/81 (Different encoding of value)
* https://github.com/pquerna/ffjson/issues/75 (Pointer to string with tag "string" has a closing quotation.)

It adds (disabled) test for these issues:
* https://github.com/pquerna/ffjson/issues/82 (Decoder: Attempting to decode null value)
* https://github.com/pquerna/ffjson/issues/80 (Support "string" tag in decoder)

Sorry about the big blob, but keeping tests in sync was important for me.