### PR TITLE
Add basic support for Unmarshall's case insensitive key finding

### DIFF
--- a/fflib/v1/fold.go
+++ b/fflib/v1/fold.go
@@ -1,0 +1,121 @@
+/**
+ *  Copyright 2014 Paul Querna
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+/* Portions of this file are on Go stdlib's encoding/json/fold.go */
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package v1
+
+import (
+	"unicode/utf8"
+)
+
+const (
+	caseMask     = ^byte(0x20) // Mask to ignore case in ASCII.
+	kelvin       = '\u212a'
+	smallLongEss = '\u017f'
+)
+
+// equalFoldRight is a specialization of bytes.EqualFold when s is
+// known to be all ASCII (including punctuation), but contains an 's',
+// 'S', 'k', or 'K', requiring a Unicode fold on the bytes in t.
+// See comments on foldFunc.
+func EqualFoldRight(s, t []byte) bool {
+	for _, sb := range s {
+		if len(t) == 0 {
+			return false
+		}
+		tb := t[0]
+		if tb < utf8.RuneSelf {
+			if sb != tb {
+				sbUpper := sb & caseMask
+				if 'A' <= sbUpper && sbUpper <= 'Z' {
+					if sbUpper != tb&caseMask {
+						return false
+					}
+				} else {
+					return false
+				}
+			}
+			t = t[1:]
+			continue
+		}
+		// sb is ASCII and t is not. t must be either kelvin
+		// sign or long s; sb must be s, S, k, or K.
+		tr, size := utf8.DecodeRune(t)
+		switch sb {
+		case 's', 'S':
+			if tr != smallLongEss {
+				return false
+			}
+		case 'k', 'K':
+			if tr != kelvin {
+				return false
+			}
+		default:
+			return false
+		}
+		t = t[size:]
+
+	}
+	if len(t) > 0 {
+		return false
+	}
+	return true
+}
+
+// asciiEqualFold is a specialization of bytes.EqualFold for use when
+// s is all ASCII (but may contain non-letters) and contains no
+// special-folding letters.
+// See comments on foldFunc.
+func AsciiEqualFold(s, t []byte) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i, sb := range s {
+		tb := t[i]
+		if sb == tb {
+			continue
+		}
+		if ('a' <= sb && sb <= 'z') || ('A' <= sb && sb <= 'Z') {
+			if sb&caseMask != tb&caseMask {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+// simpleLetterEqualFold is a specialization of bytes.EqualFold for
+// use when s is all ASCII letters (no underscores, etc) and also
+// doesn't contain 'k', 'K', 's', or 'S'.
+// See comments on foldFunc.
+func SimpleLetterEqualFold(s, t []byte) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i, b := range s {
+		if b&caseMask != t[i]&caseMask {
+			return false
+		}
+	}
+	return true
+}

--- a/inception/decoder_tpl.go
+++ b/inception/decoder_tpl.go
@@ -406,6 +406,13 @@ mainparse:
 					{{end}} }
 				{{end}}
 				}
+				{{range $index, $field := $si.ReverseFields}}
+				if bytes.EqualFold(ffj_key_{{$si.Name}}_{{$field.Name}}, kn) {
+					currentKey = ffj_t_{{$si.Name}}_{{$field.Name}}
+					state = fflib.FFParse_want_colon
+					goto mainparse
+				}
+				{{end}}
 				currentKey = ffj_t_{{.SI.Name}}no_such_key
 				state = fflib.FFParse_want_colon
 				goto mainparse

--- a/inception/decoder_tpl.go
+++ b/inception/decoder_tpl.go
@@ -407,7 +407,7 @@ mainparse:
 				{{end}}
 				}
 				{{range $index, $field := $si.ReverseFields}}
-				if bytes.EqualFold(ffj_key_{{$si.Name}}_{{$field.Name}}, kn) {
+				if {{$field.FoldFuncName}}(ffj_key_{{$si.Name}}_{{$field.Name}}, kn) {
 					currentKey = ffj_t_{{$si.Name}}_{{$field.Name}}
 					state = fflib.FFParse_want_colon
 					goto mainparse

--- a/inception/reflect.go
+++ b/inception/reflect.go
@@ -72,6 +72,15 @@ func (si *StructInfo) FieldsByFirstByte() map[string][]*StructField {
 	return rv
 }
 
+func (si *StructInfo) ReverseFields() []*StructField {
+	var i int
+	rv := make([]*StructField, 0)
+	for i = len(si.Fields) - 1; i >= 0; i-- {
+		rv = append(rv, si.Fields[i])
+	}
+	return rv
+}
+
 type MarshalerFaster interface {
 	MarshalJSONBuf(buf fflib.EncodingBuffer) error
 }

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -594,3 +594,19 @@ func TestNoEncoder(t *testing.T) {
 		require.FailNow(t, "NoEncoder should not have a MarshalJSONBuf")
 	}
 }
+
+func TestCaseSensitiveUnmarshalSimple(t *testing.T) {
+	base := Tint{}
+	ff := Xint{}
+
+	err := json.Unmarshal([]byte(`{"x": 123213}`), &base)
+	if err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+
+	err = json.Unmarshal([]byte(`{"x": 123213}`), &ff)
+	if err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	require.EqualValues(t, base, ff, "json.Unmarshal of Record with mixed case JSON")
+}


### PR DESCRIPTION
Addressing #84 

Work in progress:

- [x] non `bytes.EqualFold` case insensitive compare functions. (maybe added to fflib)
- [ ] optimizations to avoid N comparisons for keys that we aren't Unmarshalling (consider a lower cased `switch` or other ideas)