### PR TITLE
Allow directory input to ffjson.

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -22,15 +22,24 @@ import (
 	"fmt"
 )
 
-func GenerateFiles(goCmd string, inputPath string, outputPath string, importName string) error {
-	packageName, structs, err := ExtractStructs(inputPath)
-	if err != nil {
-		return err
+func GenerateFiles(goCmd string, inputPath []string, outputPath string, importName string) error {
+	var packageName string
+	var structs []*StructInfo
+	for _, input := range inputPath {
+		p, s, err := ExtractStructs(input)
+		if err != nil {
+			return err
+		}
+		if packageName != "" && p != packageName {
+			return fmt.Errorf("Multiple package names in package: %s and %s", packageName, p)
+		}
+		packageName = p
+		structs = append(structs, s...)
 	}
 
-	im := NewInceptionMain(goCmd, inputPath, outputPath)
+	im := NewInceptionMain(goCmd, inputPath[0], outputPath)
 
-	err = im.Generate(packageName, structs, importName)
+	err := im.Generate(packageName, structs, importName)
 	if err != nil {
 		return errors.New(fmt.Sprintf("error=%v path=%q", err, im.TempMainPath))
 	}


### PR DESCRIPTION
Case: When dealing with a lot of files in a single directory, it can be a bit frustrating to have to create each one, and when they are depending on eachother you may not get the "fast" encoding, because the order the files are important for ffjson to see if it can use the fast encoding. Also, with lots of files, having a _ffjson.go for each may seem suboptimal.

To solve this, I tried a small hack that encodes all files in a folder at the same time and output it to a single file.

This will parse all files ending with '.go', except files ending in "_test.go", "_ffjson.go" or "ffjson_expose.go". To specify the current directory use '.'. Directories can be absolute or relative, and if a name doesn't end in .go, it is assumed to be a directory.

The output will be placed in a single "foldername_ffjson.go" file, or whatever is specified via commandline.

If you like the idea, I will clean it up a bit and do a bit more testing, before it should be merged.
