### PR TITLE
Fix various types in slices and empty interfaces

### DIFF
--- a/inception/decoder.go
+++ b/inception/decoder.go
@@ -135,7 +135,8 @@ func handleFieldAddr(ic *Inception, name string, takeAddr bool, typ reflect.Type
 				Ptr:             reflect.Ptr,
 				UseReflectToSet: useReflectToSet,
 			})
-		} else if (typ.Elem().Kind() == reflect.Struct || typ.Elem().Kind() == reflect.Map) &&
+		} else if (typ.Elem().Kind() == reflect.Struct || typ.Elem().Kind() == reflect.Map) ||
+			typ.Elem().Kind() == reflect.Array || typ.Elem().Kind() == reflect.Slice &&
 			typ.Elem().Name() == "" {
 			out += tplStr(decodeTpl["handleFallback"], handleFallback{
 				Name: name,
@@ -210,6 +211,8 @@ func getType(ic *Inception, name string, typ reflect.Type) string {
 		switch typ.Kind() {
 		case reflect.Interface:
 			return "interface{}"
+		case reflect.Slice:
+			return "[]" + typ.Elem().String()
 		}
 		panic("non-numeric type passed in w/o name: " + name)
 	}

--- a/inception/decoder.go
+++ b/inception/decoder.go
@@ -135,6 +135,13 @@ func handleFieldAddr(ic *Inception, name string, takeAddr bool, typ reflect.Type
 				Ptr:             reflect.Ptr,
 				UseReflectToSet: useReflectToSet,
 			})
+		} else if (typ.Elem().Kind() == reflect.Struct || typ.Elem().Kind() == reflect.Map) &&
+			typ.Elem().Name() == "" {
+			out += tplStr(decodeTpl["handleFallback"], handleFallback{
+				Name: name,
+				Typ:  typ,
+				Kind: typ.Kind(),
+			})
 		} else {
 			out += tplStr(decodeTpl["handleArray"], handleArray{
 				IC:   ic,
@@ -200,6 +207,10 @@ func getType(ic *Inception, name string, typ reflect.Type) string {
 	}
 
 	if s == "" {
+		switch typ.Kind() {
+		case reflect.Interface:
+			return "interface{}"
+		}
 		panic("non-numeric type passed in w/o name: " + name)
 	}
 

--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -185,7 +185,10 @@ func getGetInnerValue(ic *Inception, name string, typ reflect.Type, ptr bool, fo
 	case reflect.Array,
 		reflect.Slice:
 
-		out += "if " + name + "!= nil {" + "\n"
+		// Arrays cannot be nil
+		if typ.Kind() != reflect.Array {
+			out += "if " + name + "!= nil {" + "\n"
+		}
 		// Array and slice values encode as JSON arrays, except that
 		// []byte encodes as a base64-encoded string, and a nil slice
 		// encodes as the null JSON object.
@@ -215,10 +218,11 @@ func getGetInnerValue(ic *Inception, name string, typ reflect.Type, ptr bool, fo
 			out += "}" + "\n"
 			out += "buf.WriteString(`]`)" + "\n"
 		}
-		out += "} else {" + "\n"
-		out += "buf.WriteString(`null`)" + "\n"
-		out += "}" + "\n"
-
+		if typ.Kind() != reflect.Array {
+			out += "} else {" + "\n"
+			out += "buf.WriteString(`null`)" + "\n"
+			out += "}" + "\n"
+		}
 	case reflect.String:
 		ic.OutputImports[`fflib "github.com/pquerna/ffjson/fflib/v1"`] = true
 		if forceString {

--- a/tests/ff.go
+++ b/tests/ff.go
@@ -1078,6 +1078,7 @@ type TEmbeddedStructures struct {
 	W [5]map[string]struct {
 		X int
 	}
+	Q [][]string
 }
 
 type XEmbeddedStructures struct {
@@ -1097,4 +1098,5 @@ type XEmbeddedStructures struct {
 	W [5]map[string]struct {
 		X int
 	}
+	Q [][]string
 }

--- a/tests/ff.go
+++ b/tests/ff.go
@@ -1059,3 +1059,42 @@ type NoDecoder struct {
 	C string
 	B int `json:"A"`
 }
+
+// ffjson: skip
+type TEmbeddedStructures struct {
+	X []interface{}
+	Y struct {
+		X int
+	}
+	Z []struct {
+		X int
+	}
+	U map[string]struct {
+		X int
+	}
+	V []map[string]struct {
+		X int
+	}
+	W [5]map[string]struct {
+		X int
+	}
+}
+
+type XEmbeddedStructures struct {
+	X []interface{}
+	Y struct {
+		X int
+	}
+	Z []struct {
+		X int
+	}
+	U map[string]struct {
+		X int
+	}
+	V []map[string]struct {
+		X int
+	}
+	W [5]map[string]struct {
+		X int
+	}
+}

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -610,3 +610,48 @@ func TestCaseSensitiveUnmarshalSimple(t *testing.T) {
 	}
 	require.EqualValues(t, base, ff, "json.Unmarshal of Record with mixed case JSON")
 }
+
+func TestEmbedded(t *testing.T) {
+	a := TEmbeddedStructures{}
+	a.X = make([]interface{}, 0)
+	a.X = append(a.X, "testString")
+	a.Y.X = 73
+	a.Z = make([]struct{ X int }, 2)
+	a.Z[0].X = 12
+	a.Z[1].X = 34
+	a.U = make(map[string]struct{ X int })
+	a.U["sample"] = struct{ X int }{X: 56}
+	a.U["value"] = struct{ X int }{X: 78}
+	a.V = make([]map[string]struct{ X int }, 3)
+	for i := range a.V {
+		a.V[i] = make(map[string]struct{ X int })
+		a.V[i]["sample"] = struct{ X int }{X: i * 3}
+	}
+	for i := range a.W {
+		a.W[i] = make(map[string]struct{ X int })
+		a.W[i]["sample"] = struct{ X int }{X: i * 3}
+		a.W[i]["value"] = struct{ X int }{X: i * 5}
+	}
+	b := XEmbeddedStructures{}
+	b.X = make([]interface{}, 0)
+	b.X = append(b.X, "testString")
+	b.Y.X = 73
+	b.Z = make([]struct{ X int }, 2)
+	b.Z[0].X = 12
+	b.Z[1].X = 34
+	b.U = make(map[string]struct{ X int })
+	b.U["sample"] = struct{ X int }{X: 56}
+	b.U["value"] = struct{ X int }{X: 78}
+	b.V = make([]map[string]struct{ X int }, 3)
+	for i := range b.V {
+		b.V[i] = make(map[string]struct{ X int })
+		b.V[i]["sample"] = struct{ X int }{X: i * 3}
+	}
+	for i := range b.W {
+		b.W[i] = make(map[string]struct{ X int })
+		b.W[i]["sample"] = struct{ X int }{X: i * 3}
+		b.W[i]["value"] = struct{ X int }{X: i * 5}
+	}
+	testSameMarshal(t, &a, &b)
+	testCycle(t, &a, &b)
+}

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -632,6 +632,12 @@ func TestEmbedded(t *testing.T) {
 		a.W[i]["sample"] = struct{ X int }{X: i * 3}
 		a.W[i]["value"] = struct{ X int }{X: i * 5}
 	}
+	a.Q = make([][]string, 3)
+	for i := range a.Q {
+		a.Q[i] = make([]string, 1)
+		a.Q[i][0] = fmt.Sprintf("thestring #%d", i)
+	}
+
 	b := XEmbeddedStructures{}
 	b.X = make([]interface{}, 0)
 	b.X = append(b.X, "testString")
@@ -651,6 +657,11 @@ func TestEmbedded(t *testing.T) {
 		b.W[i] = make(map[string]struct{ X int })
 		b.W[i]["sample"] = struct{ X int }{X: i * 3}
 		b.W[i]["value"] = struct{ X int }{X: i * 5}
+	}
+	b.Q = make([][]string, 3)
+	for i := range a.Q {
+		b.Q[i] = make([]string, 1)
+		b.Q[i][0] = fmt.Sprintf("thestring #%d", i)
 	}
 	testSameMarshal(t, &a, &b)
 	testCycle(t, &a, &b)


### PR DESCRIPTION
Mainly by falling back to reflection.

This should solve #89, #44 and #40 

This also addresses an issue found while testing, where encoding of arrays resulted in invalid code.