### PR TITLE
Fix skipped types

### DIFF
--- a/inception/decoder.go
+++ b/inception/decoder.go
@@ -19,6 +19,7 @@ package ffjsoninception
 
 import (
 	"fmt"
+	"github.com/pquerna/ffjson/shared"
 	"reflect"
 )
 
@@ -62,7 +63,7 @@ func handleFieldAddr(ic *Inception, name string, takeAddr bool, typ reflect.Type
 	out := ""
 	out += fmt.Sprintf("/* handler: %s type=%v kind=%v */\n", name, typ, typ.Kind())
 
-	umlx := typ.Implements(unmarshalFasterType) || typeInInception(ic, typ)
+	umlx := typ.Implements(unmarshalFasterType) || typeInInception(ic, typ, shared.MustDecoder)
 	umlstd := typ.Implements(unmarshalerType) || reflect.PtrTo(typ).Implements(unmarshalerType)
 
 	out += tplStr(decodeTpl["handleUnmarshaler"], handleUnmarshaler{

--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -19,17 +19,18 @@ package ffjsoninception
 
 import (
 	"fmt"
+	"github.com/pquerna/ffjson/shared"
 	"reflect"
 )
 
-func typeInInception(ic *Inception, typ reflect.Type) bool {
+func typeInInception(ic *Inception, typ reflect.Type, f shared.Feature) bool {
 	for _, v := range ic.objs {
 		if v.Typ == typ {
-			return true
+			return v.Options.HasFeature(f)
 		}
 		if typ.Kind() == reflect.Ptr {
 			if v.Typ == typ.Elem() {
-				return true
+				return v.Options.HasFeature(f)
 			}
 		}
 	}
@@ -142,14 +143,14 @@ func getGetInnerValue(ic *Inception, name string, typ reflect.Type, ptr bool, fo
 
 	if typ.Implements(marshalerFasterType) ||
 		reflect.PtrTo(typ).Implements(marshalerFasterType) ||
-		typeInInception(ic, typ) ||
+		typeInInception(ic, typ, shared.MustEncoder) ||
 		typ.Implements(marshalerType) ||
 		reflect.PtrTo(typ).Implements(marshalerType) {
 
 		out += tplStr(encodeTpl["handleMarshaler"], handleMarshaler{
 			IC:             ic,
 			Name:           name,
-			MarshalJSONBuf: typ.Implements(marshalerFasterType) || reflect.PtrTo(typ).Implements(marshalerFasterType) || typeInInception(ic, typ),
+			MarshalJSONBuf: typ.Implements(marshalerFasterType) || reflect.PtrTo(typ).Implements(marshalerFasterType) || typeInInception(ic, typ, shared.MustEncoder),
 			Marshaler:      typ.Implements(marshalerType) || reflect.PtrTo(typ).Implements(marshalerType),
 		})
 		return out

--- a/shared/options.go
+++ b/shared/options.go
@@ -26,3 +26,26 @@ type InceptionType struct {
 	Obj     interface{}
 	Options StructOptions
 }
+type Feature int
+
+const (
+	Nothing     Feature = 0
+	MustDecoder         = 1 << 1
+	MustEncoder         = 1 << 2
+	MustEncDec          = MustDecoder | MustEncoder
+)
+
+func (i InceptionType) HasFeature(f Feature) bool {
+	return i.HasFeature(f)
+}
+
+func (s StructOptions) HasFeature(f Feature) bool {
+	hasNeeded := true
+	if f&MustDecoder != 0 && s.SkipDecoder {
+		hasNeeded = false
+	}
+	if f&MustEncoder != 0 && s.SkipEncoder {
+		hasNeeded = false
+	}
+	return hasNeeded
+}

--- a/tests/ff.go
+++ b/tests/ff.go
@@ -1100,3 +1100,23 @@ type XEmbeddedStructures struct {
 	}
 	Q [][]string
 }
+
+// ffjson: skip
+// Side-effect of this test is also to verify that Encoder/Decoder skipping works.
+type TRenameTypes struct {
+	X struct {
+		X int
+	} `json:"X-renamed"`
+	Y NoEncoder  `json:"Y-renamed"`
+	Z string     `json:"Z-renamed"`
+	U *NoDecoder `json:"U-renamed"`
+}
+
+type XRenameTypes struct {
+	X struct {
+		X int
+	} `json:"X-renamed"`
+	Y NoEncoder  `json:"Y-renamed"`
+	Z string     `json:"Z-renamed"`
+	U *NoDecoder `json:"U-renamed"`
+}

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -666,3 +666,7 @@ func TestEmbedded(t *testing.T) {
 	testSameMarshal(t, &a, &b)
 	testCycle(t, &a, &b)
 }
+
+func TestRenameTypes(t *testing.T) {
+	testType(t, &TRenameTypes{}, &XRenameTypes{})
+}


### PR DESCRIPTION
Fix cases where other objects are asking if the type is in inception. However if only encoder/decoder is included it would assume both where included.

Came up as a side-effect of another test i wrote.