### PR TITLE
Buffer Pooling

### DIFF
--- a/fflib/v1/buffer.go
+++ b/fflib/v1/buffer.go
@@ -125,7 +125,7 @@ func Pool(b []byte) {
 	c := cap(b)
 	pn := poolNum(c)
 	if pn != -1 {
-		pools[pn].Put(b)
+		pools[pn].Put(b[0:0])
 	}
 	// if we didn't have a slot for this []byte, we just drop it and let the GC
 	// take care of it.

--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -394,7 +394,6 @@ func CreateMarshalJSON(ic *Inception, si *StructInfo) error {
 	out += `func (mj *` + si.Name + `) MarshalJSON() ([]byte, error) {` + "\n"
 	out += `var buf fflib.Buffer` + "\n"
 
-	out += fmt.Sprintf("buf.Grow(%d)\n", getBufGrowSize(si))
 	out += `err := mj.MarshalJSONBuf(&buf)` + "\n"
 	out += `if err != nil {` + "\n"
 	out += "  return nil, err" + "\n"

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -121,10 +121,6 @@ func BenchmarkMarshalJSONNativeReuse(b *testing.B) {
 			b.Fatalf("Marshal: %v", err)
 		}
 		buffer.Reset()
-		if err != nil {
-			b.Fatalf("Marshal: %v", err)
-		}
-		buffer.Reset()
 	}
 }
 

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -85,7 +85,6 @@ func BenchmarkMarshalJSONNative(b *testing.B) {
 	}
 }
 
-/*
 func BenchmarkMarshalJSONNativePool(b *testing.B) {
 	record := newLogFFRecord()
 
@@ -104,7 +103,7 @@ func BenchmarkMarshalJSONNativePool(b *testing.B) {
 		fflib.Pool(bytes)
 	}
 }
-*/
+
 func BenchmarkMarshalJSONNativeReuse(b *testing.B) {
 	record := newLogFFRecord()
 


### PR DESCRIPTION
rebased version of @klauspost's #72, adds:

- `sync.Pool`s for multiple sizes of `[]byte`
- free's back pools in a few more situations.