### PR TITLE
Work out a way to display warnings

### DIFF
--- a/inception/reflect.go
+++ b/inception/reflect.go
@@ -23,6 +23,7 @@ import (
 
 	"bytes"
 	"encoding/json"
+	"log"
 	"reflect"
 	"unicode/utf8"
 )
@@ -272,6 +273,7 @@ func dominantField(fields []*StructField) (*StructField, bool) {
 			if tagged >= 0 {
 				// Multiple tagged fields at the same level: conflict.
 				// Return no field.
+				log.Printf("Warning: Duplicate tagged entry with entry %s found. Ignoring entries.", f.JsonName, f.Typ)
 				return nil, false
 			}
 			tagged = i


### PR DESCRIPTION
I have found a few cases, where it would be a nice service to print a warning:
- Duplicate field names.
- Usage of ",string" on unsupported types.
- Maybe when field dominance is used.

However, currently ffjson eats up warnings and only displays anything, if an error code is returned.

Would it make sense to be able to pass through warnings like the one in this PR?
