### PR TITLE
Disable SSE4.2 on App Engine

### DIFF
--- a/fflib/v1/reader_scan_amd64.go
+++ b/fflib/v1/reader_scan_amd64.go
@@ -1,4 +1,5 @@
 // +build amd64
+// +build !appengine
 
 /**
  *  Copyright 2014 Paul Querna
@@ -22,7 +23,12 @@ package v1
 func haveSSE42() bool
 func scanStringSSE(s []byte, j int) (int, byte)
 
+var sse42 = haveSSE42()
+
 func scanString(s []byte, j int) (int, byte) {
+	if false && sse42 {
+		return scanStringSSE(s, j)
+	}
 
 	for {
 		if j >= len(s) {

--- a/fflib/v1/reader_scan_amd64.go
+++ b/fflib/v1/reader_scan_amd64.go
@@ -22,12 +22,7 @@ package v1
 func haveSSE42() bool
 func scanStringSSE(s []byte, j int) (int, byte)
 
-var sse42 = haveSSE42()
-
 func scanString(s []byte, j int) (int, byte) {
-	if false && sse42 {
-		return scanStringSSE(s, j)
-	}
 
 	for {
 		if j >= len(s) {

--- a/fflib/v1/reader_scan_generic.go
+++ b/fflib/v1/reader_scan_generic.go
@@ -1,4 +1,4 @@
-// +build !amd64
+// +build !amd64 appengine
 
 /**
  *  Copyright 2014 Paul Querna


### PR DESCRIPTION
Having this unused code makes App Engine compiles fail, since it cannot  find the "func haveSSE42() bool"/scanStringSSE function.

So let's remove them until we need them.