### PR TITLE
Add tests for field/struct renaming and dominant fields.

### DIFF
--- a/tests/ff.go
+++ b/tests/ff.go
@@ -1100,3 +1100,40 @@ type XEmbeddedStructures struct {
 	}
 	Q [][]string
 }
+
+// ffjson: skip
+// Side-effect of this test is also to verify that Encoder/Decoder skipping works.
+type TRenameTypes struct {
+	X struct {
+		X int
+	} `json:"X-renamed"`
+	Y NoEncoder  `json:"Y-renamed"`
+	Z string     `json:"Z-renamed"`
+	U *NoDecoder `json:"U-renamed"`
+}
+
+type XRenameTypes struct {
+	X struct {
+		X int
+	} `json:"X-renamed"`
+	Y NoEncoder  `json:"Y-renamed"`
+	Z string     `json:"Z-renamed"`
+	U *NoDecoder `json:"U-renamed"`
+}
+
+// ffjson: skip
+type TDominantField struct {
+	X     *int `json:"Name,omitempty"`
+	Y     *int `json:"Name,omitempty"`
+	Other string
+	Name  *int             `json",omitempty"`
+	A     *struct{ X int } `json:"Name,omitempty"`
+}
+
+type XDominantField struct {
+	X     *int `json:"Name,omitempty"`
+	Y     *int `json:"Name,omitempty"`
+	Other string
+	Name  *int             `json",omitempty"`
+	A     *struct{ X int } `json:"Name,omitempty"`
+}

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -666,3 +666,15 @@ func TestEmbedded(t *testing.T) {
 	testSameMarshal(t, &a, &b)
 	testCycle(t, &a, &b)
 }
+
+func TestRenameTypes(t *testing.T) {
+	testType(t, &TRenameTypes{}, &XRenameTypes{})
+}
+
+// This tests that we behave the same way as encoding/json.
+// That means that if there is more than one field that has the same name
+// set via the json tag ALL fields with this name are dropped.
+func TestDominantField(t *testing.T) {
+	i := 43
+	testType(t, &TDominantField{Y: &i}, &XDominantField{Y: &i})
+}


### PR DESCRIPTION
Test for dominant fields/structs.

Had this laying around, so I wanted to send it in before I forgot.

Unfortunately it has bit-rotted, but adding them should be a matter of 2 copy+paste.