### PR TITLE
Use ff unmarshaler for pointer types from different files, if possible.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,19 @@ test-core:
 test: ffize test-core
 	go test -v github.com/pquerna/ffjson/tests/...
 
+STRIPE_SPLIT_FILES = card.go carddata.go coupon.go customer.go discount.go plan.go subscription.go
+
 ffize: install
 	ffjson tests/ff.go
 	ffjson tests/goser/ff/goser.go
 	ffjson tests/go.stripe/ff/customer.go
 	ffjson tests/types/ff/everything.go
+	for file in $(STRIPE_SPLIT_FILES); do \
+		ffjson tests/go.stripe.split/ff/$$file; \
+	done
+	for file in $(STRIPE_SPLIT_FILES); do \
+		ffjson tests/go.stripe.split/ff/$$file; \
+	done
 
 bench: ffize all
 	go test -v -benchmem -bench MarshalJSON  github.com/pquerna/ffjson/tests

--- a/inception/decoder.go
+++ b/inception/decoder.go
@@ -63,7 +63,9 @@ func handleFieldAddr(ic *Inception, name string, takeAddr bool, typ reflect.Type
 	out := ""
 	out += fmt.Sprintf("/* handler: %s type=%v kind=%v */\n", name, typ, typ.Kind())
 
-	umlx := typ.Implements(unmarshalFasterType) || typeInInception(ic, typ, shared.MustDecoder)
+	umlx := typ.Implements(unmarshalFasterType) ||
+		reflect.PtrTo(typ).Implements(unmarshalFasterType) ||
+		typeInInception(ic, typ, shared.MustDecoder)
 	umlstd := typ.Implements(unmarshalerType) || reflect.PtrTo(typ).Implements(unmarshalerType)
 
 	out += tplStr(decodeTpl["handleUnmarshaler"], handleUnmarshaler{

--- a/tests/go.stripe.split/base/card.go
+++ b/tests/go.stripe.split/base/card.go
@@ -1,0 +1,33 @@
+package stripe
+
+// Credit Card Types accepted by the Stripe API.
+const (
+	AmericanExpress = "American Express"
+	DinersClub      = "Diners Club"
+	Discover        = "Discover"
+	JCB             = "JCB"
+	MasterCard      = "MasterCard"
+	Visa            = "Visa"
+	UnknownCard     = "Unknown"
+)
+
+// Card represents details about a Credit Card entered into Stripe.
+type Card struct {
+	Id                string `json:"id"`
+	Name              string `json:"name,omitempty"`
+	Type              string `json:"type"`
+	ExpMonth          int    `json:"exp_month"`
+	ExpYear           int    `json:"exp_year"`
+	Last4             string `json:"last4"`
+	Fingerprint       string `json:"fingerprint"`
+	Country           string `json:"country,omitempty"`
+	AddrUess1         string `json:"address_line1,omitempty"`
+	Address2          string `json:"address_line2,omitempty"`
+	AddressCountry    string `json:"address_country,omitempty"`
+	AddressState      string `json:"address_state,omitempty"`
+	AddressZip        string `json:"address_zip,omitempty"`
+	AddressCity       string `json:"address_city"`
+	AddressLine1Check string `json:"address_line1_check,omitempty"`
+	AddressZipCheck   string `json:"address_zip_check,omitempty"`
+	CVCCheck          string `json:"cvc_check,omitempty"`
+}

--- a/tests/go.stripe.split/base/carddata.go
+++ b/tests/go.stripe.split/base/carddata.go
@@ -1,0 +1,8 @@
+package stripe
+
+type CardData struct {
+	Object string  `json:"object"`
+	Count  int     `json:"count"`
+	Url    string  `json:"url"`
+	Data   []*Card `json:"data"`
+}

--- a/tests/go.stripe.split/base/coupon.go
+++ b/tests/go.stripe.split/base/coupon.go
@@ -1,0 +1,15 @@
+package stripe
+
+// Coupon represents percent-off discount you might want to apply to a customer.
+//
+// see https://stripe.com/docs/api#coupon_object
+type Coupon struct {
+	Id               string `json:"id"`
+	Duration         string `json:"duration"`
+	PercentOff       int    `json:"percent_off"`
+	DurationInMonths int    `json:"duration_in_months,omitempty"`
+	MaxRedemptions   int    `json:"max_redemptions,omitempty"`
+	RedeemBy         int64  `json:"redeem_by,omitempty"`
+	TimesRedeemed    int    `json:"times_redeemed,omitempty"`
+	Livemode         bool   `json:"livemode"`
+}

--- a/tests/go.stripe.split/base/customer.go
+++ b/tests/go.stripe.split/base/customer.go
@@ -1,0 +1,89 @@
+package stripe
+
+import (
+	"time"
+)
+
+// Customer encapsulates details about a Customer registered in Stripe.
+//
+// see https://stripe.com/docs/api#customer_object
+type Customer struct {
+	Id           string        `json:"id"`
+	Desc         string        `json:"description,omitempty"`
+	Email        string        `json:"email,omitempty"`
+	Created      int64         `json:"created"`
+	Balance      int64         `json:"account_balance"`
+	Delinquent   bool          `json:"delinquent"`
+	Cards        CardData      `json:"cards,omitempty"`
+	Discount     *Discount     `json:"discount,omitempty"`
+	Subscription *Subscription `json:"subscription,omitempty"`
+	Livemode     bool          `json:"livemode"`
+	DefaultCard  string        `json:"default_card"`
+}
+
+func NewCustomer() *Customer {
+
+	return &Customer{
+		Id:         "hooN5ne7ug",
+		Desc:       "A very nice customer.",
+		Email:      "customer@example.com",
+		Created:    time.Now().UnixNano(),
+		Balance:    10,
+		Delinquent: false,
+		Cards: CardData{
+			Object: "A92F4CFE-8B6B-4176-873E-887AC0D120EB",
+			Count:  1,
+			Url:    "https://stripe.example.com/card/A92F4CFE-8B6B-4176-873E-887AC0D120EB",
+			Data: []*Card{
+				&Card{
+					Name:        "John Smith",
+					Id:          "7526EC97-A0B6-47B2-AAE5-17443626A116",
+					Fingerprint: "4242424242424242",
+					ExpYear:     time.Now().Year() + 1,
+					ExpMonth:    1,
+				},
+			},
+		},
+		Discount: &Discount{
+			Id:       "Ee9ieZ8zie",
+			Customer: "hooN5ne7ug",
+			Start:    time.Now().UnixNano(),
+			End:      time.Now().UnixNano(),
+			Coupon: &Coupon{
+				Id:               "ieQuo5Aiph",
+				Duration:         "2m",
+				PercentOff:       10,
+				DurationInMonths: 2,
+				MaxRedemptions:   1,
+				RedeemBy:         time.Now().UnixNano(),
+				TimesRedeemed:    1,
+				Livemode:         true,
+			},
+		},
+		Subscription: &Subscription{
+			Customer: "hooN5ne7ug",
+			Status:   SubscriptionActive,
+			Plan: &Plan{
+				Id:              "gaiyeLua5u",
+				Name:            "Great Plan (TM)",
+				Amount:          10,
+				Interval:        "monthly",
+				IntervalCount:   3,
+				Currency:        "USD",
+				TrialPeriodDays: 15,
+				Livemode:        true,
+			},
+			Start:              time.Now().UnixNano(),
+			EndedAt:            0,
+			CurrentPeriodStart: time.Now().UnixNano(),
+			CurrentPeriodEnd:   time.Now().UnixNano(),
+			TrialStart:         time.Now().UnixNano(),
+			TrialEnd:           time.Now().UnixNano(),
+			CanceledAt:         0,
+			CancelAtPeriodEnd:  false,
+			Quantity:           2,
+		},
+		Livemode:    true,
+		DefaultCard: "7526EC97-A0B6-47B2-AAE5-17443626A116",
+	}
+}

--- a/tests/go.stripe.split/base/discount.go
+++ b/tests/go.stripe.split/base/discount.go
@@ -1,0 +1,13 @@
+package stripe
+
+// Discount represents the actual application of a coupon to a particular
+// customer.
+//
+// see https://stripe.com/docs/api#discount_object
+type Discount struct {
+	Id       string  `json:"id"`
+	Customer string  `json:"customer"`
+	Start    int64   `json:"start"`
+	End      int64   `json:"end"`
+	Coupon   *Coupon `json:"coupon"`
+}

--- a/tests/go.stripe.split/base/plan.go
+++ b/tests/go.stripe.split/base/plan.go
@@ -1,0 +1,17 @@
+package stripe
+
+// Plan holds details about pricing information for different products and
+// feature levels on your site. For example, you might have a $10/month plan
+// for basic features and a different $20/month plan for premium features.
+//
+// see https://stripe.com/docs/api#plan_object
+type Plan struct {
+	Id              string `json:"id"`
+	Name            string `json:"name"`
+	Amount          int64  `json:"amount"`
+	Interval        string `json:"interval"`
+	IntervalCount   int    `json:"interval_count"`
+	Currency        string `json:"currency"`
+	TrialPeriodDays int    `json:"trial_period_days"`
+	Livemode        bool   `json:"livemode"`
+}

--- a/tests/go.stripe.split/base/subscription.go
+++ b/tests/go.stripe.split/base/subscription.go
@@ -1,0 +1,28 @@
+package stripe
+
+// Subscription Statuses
+const (
+	SubscriptionTrialing = "trialing"
+	SubscriptionActive   = "active"
+	SubscriptionPastDue  = "past_due"
+	SubscriptionCanceled = "canceled"
+	SubscriptionUnpaid   = "unpaid"
+)
+
+// Subscriptions represents a recurring charge a customer's card.
+//
+// see https://stripe.com/docs/api#subscription_object
+type Subscription struct {
+	Customer           string `json:"customer"`
+	Status             string `json:"status"`
+	Plan               *Plan  `json:"plan"`
+	Start              int64  `json:"start"`
+	EndedAt            int64  `json:"ended_at"`
+	CurrentPeriodStart int64  `json:"current_period_start"`
+	CurrentPeriodEnd   int64  `json:"current_period_end"`
+	TrialStart         int64  `json:"trial_start"`
+	TrialEnd           int64  `json:"trial_end"`
+	CanceledAt         int64  `json:"canceled_at"`
+	CancelAtPeriodEnd  bool   `json:"cancel_at_period_end"`
+	Quantity           int64  `json"quantity"`
+}

--- a/tests/go.stripe.split/ff/card.go
+++ b/tests/go.stripe.split/ff/card.go
@@ -1,0 +1,33 @@
+package stripe
+
+// Credit Card Types accepted by the Stripe API.
+const (
+	AmericanExpress = "American Express"
+	DinersClub      = "Diners Club"
+	Discover        = "Discover"
+	JCB             = "JCB"
+	MasterCard      = "MasterCard"
+	Visa            = "Visa"
+	UnknownCard     = "Unknown"
+)
+
+// Card represents details about a Credit Card entered into Stripe.
+type Card struct {
+	Id                string `json:"id"`
+	Name              string `json:"name,omitempty"`
+	Type              string `json:"type"`
+	ExpMonth          int    `json:"exp_month"`
+	ExpYear           int    `json:"exp_year"`
+	Last4             string `json:"last4"`
+	Fingerprint       string `json:"fingerprint"`
+	Country           string `json:"country,omitempty"`
+	AddrUess1         string `json:"address_line1,omitempty"`
+	Address2          string `json:"address_line2,omitempty"`
+	AddressCountry    string `json:"address_country,omitempty"`
+	AddressState      string `json:"address_state,omitempty"`
+	AddressZip        string `json:"address_zip,omitempty"`
+	AddressCity       string `json:"address_city"`
+	AddressLine1Check string `json:"address_line1_check,omitempty"`
+	AddressZipCheck   string `json:"address_zip_check,omitempty"`
+	CVCCheck          string `json:"cvc_check,omitempty"`
+}

--- a/tests/go.stripe.split/ff/carddata.go
+++ b/tests/go.stripe.split/ff/carddata.go
@@ -1,0 +1,8 @@
+package stripe
+
+type CardData struct {
+	Object string  `json:"object"`
+	Count  int     `json:"count"`
+	Url    string  `json:"url"`
+	Data   []*Card `json:"data"`
+}

--- a/tests/go.stripe.split/ff/coupon.go
+++ b/tests/go.stripe.split/ff/coupon.go
@@ -1,0 +1,15 @@
+package stripe
+
+// Coupon represents percent-off discount you might want to apply to a customer.
+//
+// see https://stripe.com/docs/api#coupon_object
+type Coupon struct {
+	Id               string `json:"id"`
+	Duration         string `json:"duration"`
+	PercentOff       int    `json:"percent_off"`
+	DurationInMonths int    `json:"duration_in_months,omitempty"`
+	MaxRedemptions   int    `json:"max_redemptions,omitempty"`
+	RedeemBy         int64  `json:"redeem_by,omitempty"`
+	TimesRedeemed    int    `json:"times_redeemed,omitempty"`
+	Livemode         bool   `json:"livemode"`
+}

--- a/tests/go.stripe.split/ff/customer.go
+++ b/tests/go.stripe.split/ff/customer.go
@@ -1,0 +1,89 @@
+package stripe
+
+import (
+	"time"
+)
+
+// Customer encapsulates details about a Customer registered in Stripe.
+//
+// see https://stripe.com/docs/api#customer_object
+type Customer struct {
+	Id           string        `json:"id"`
+	Desc         string        `json:"description,omitempty"`
+	Email        string        `json:"email,omitempty"`
+	Created      int64         `json:"created"`
+	Balance      int64         `json:"account_balance"`
+	Delinquent   bool          `json:"delinquent"`
+	Cards        CardData      `json:"cards,omitempty"`
+	Discount     *Discount     `json:"discount,omitempty"`
+	Subscription *Subscription `json:"subscription,omitempty"`
+	Livemode     bool          `json:"livemode"`
+	DefaultCard  string        `json:"default_card"`
+}
+
+func NewCustomer() *Customer {
+
+	return &Customer{
+		Id:         "hooN5ne7ug",
+		Desc:       "A very nice customer.",
+		Email:      "customer@example.com",
+		Created:    time.Now().UnixNano(),
+		Balance:    10,
+		Delinquent: false,
+		Cards: CardData{
+			Object: "A92F4CFE-8B6B-4176-873E-887AC0D120EB",
+			Count:  1,
+			Url:    "https://stripe.example.com/card/A92F4CFE-8B6B-4176-873E-887AC0D120EB",
+			Data: []*Card{
+				&Card{
+					Name:        "John Smith",
+					Id:          "7526EC97-A0B6-47B2-AAE5-17443626A116",
+					Fingerprint: "4242424242424242",
+					ExpYear:     time.Now().Year() + 1,
+					ExpMonth:    1,
+				},
+			},
+		},
+		Discount: &Discount{
+			Id:       "Ee9ieZ8zie",
+			Customer: "hooN5ne7ug",
+			Start:    time.Now().UnixNano(),
+			End:      time.Now().UnixNano(),
+			Coupon: &Coupon{
+				Id:               "ieQuo5Aiph",
+				Duration:         "2m",
+				PercentOff:       10,
+				DurationInMonths: 2,
+				MaxRedemptions:   1,
+				RedeemBy:         time.Now().UnixNano(),
+				TimesRedeemed:    1,
+				Livemode:         true,
+			},
+		},
+		Subscription: &Subscription{
+			Customer: "hooN5ne7ug",
+			Status:   SubscriptionActive,
+			Plan: &Plan{
+				Id:              "gaiyeLua5u",
+				Name:            "Great Plan (TM)",
+				Amount:          10,
+				Interval:        "monthly",
+				IntervalCount:   3,
+				Currency:        "USD",
+				TrialPeriodDays: 15,
+				Livemode:        true,
+			},
+			Start:              time.Now().UnixNano(),
+			EndedAt:            0,
+			CurrentPeriodStart: time.Now().UnixNano(),
+			CurrentPeriodEnd:   time.Now().UnixNano(),
+			TrialStart:         time.Now().UnixNano(),
+			TrialEnd:           time.Now().UnixNano(),
+			CanceledAt:         0,
+			CancelAtPeriodEnd:  false,
+			Quantity:           2,
+		},
+		Livemode:    true,
+		DefaultCard: "7526EC97-A0B6-47B2-AAE5-17443626A116",
+	}
+}

--- a/tests/go.stripe.split/ff/discount.go
+++ b/tests/go.stripe.split/ff/discount.go
@@ -1,0 +1,13 @@
+package stripe
+
+// Discount represents the actual application of a coupon to a particular
+// customer.
+//
+// see https://stripe.com/docs/api#discount_object
+type Discount struct {
+	Id       string  `json:"id"`
+	Customer string  `json:"customer"`
+	Start    int64   `json:"start"`
+	End      int64   `json:"end"`
+	Coupon   *Coupon `json:"coupon"`
+}

--- a/tests/go.stripe.split/ff/plan.go
+++ b/tests/go.stripe.split/ff/plan.go
@@ -1,0 +1,17 @@
+package stripe
+
+// Plan holds details about pricing information for different products and
+// feature levels on your site. For example, you might have a $10/month plan
+// for basic features and a different $20/month plan for premium features.
+//
+// see https://stripe.com/docs/api#plan_object
+type Plan struct {
+	Id              string `json:"id"`
+	Name            string `json:"name"`
+	Amount          int64  `json:"amount"`
+	Interval        string `json:"interval"`
+	IntervalCount   int    `json:"interval_count"`
+	Currency        string `json:"currency"`
+	TrialPeriodDays int    `json:"trial_period_days"`
+	Livemode        bool   `json:"livemode"`
+}

--- a/tests/go.stripe.split/ff/subscription.go
+++ b/tests/go.stripe.split/ff/subscription.go
@@ -1,0 +1,28 @@
+package stripe
+
+// Subscription Statuses
+const (
+	SubscriptionTrialing = "trialing"
+	SubscriptionActive   = "active"
+	SubscriptionPastDue  = "past_due"
+	SubscriptionCanceled = "canceled"
+	SubscriptionUnpaid   = "unpaid"
+)
+
+// Subscriptions represents a recurring charge a customer's card.
+//
+// see https://stripe.com/docs/api#subscription_object
+type Subscription struct {
+	Customer           string `json:"customer"`
+	Status             string `json:"status"`
+	Plan               *Plan  `json:"plan"`
+	Start              int64  `json:"start"`
+	EndedAt            int64  `json:"ended_at"`
+	CurrentPeriodStart int64  `json:"current_period_start"`
+	CurrentPeriodEnd   int64  `json:"current_period_end"`
+	TrialStart         int64  `json:"trial_start"`
+	TrialEnd           int64  `json:"trial_end"`
+	CanceledAt         int64  `json:"canceled_at"`
+	CancelAtPeriodEnd  bool   `json:"cancel_at_period_end"`
+	Quantity           int64  `json"quantity"`
+}

--- a/tests/go.stripe.split/stripe_test.go
+++ b/tests/go.stripe.split/stripe_test.go
@@ -1,0 +1,118 @@
+/**
+ *  Copyright 2014 Paul Querna
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package goser
+
+import (
+	"encoding/json"
+	base "github.com/pquerna/ffjson/tests/go.stripe.split/base"
+	ff "github.com/pquerna/ffjson/tests/go.stripe.split/ff"
+	"testing"
+)
+
+func TestRoundTrip(t *testing.T) {
+	var customerTripped ff.Customer
+	customer := ff.NewCustomer()
+
+	buf1, err := json.Marshal(&customer)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	err = json.Unmarshal(buf1, &customerTripped)
+	if err != nil {
+		print(string(buf1))
+		t.Fatalf("Unmarshal: %v", err)
+	}
+}
+
+func BenchmarkMarshalJSON(b *testing.B) {
+	cust := base.NewCustomer()
+
+	buf, err := json.Marshal(&cust)
+	if err != nil {
+		b.Fatalf("Marshal: %v", err)
+	}
+	b.SetBytes(int64(len(buf)))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(&cust)
+		if err != nil {
+			b.Fatalf("Marshal: %v", err)
+		}
+	}
+}
+
+func BenchmarkFFMarshalJSON(b *testing.B) {
+	cust := ff.NewCustomer()
+
+	buf, err := cust.MarshalJSON()
+	if err != nil {
+		b.Fatalf("Marshal: %v", err)
+	}
+	b.SetBytes(int64(len(buf)))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := cust.MarshalJSON()
+		if err != nil {
+			b.Fatalf("Marshal: %v", err)
+		}
+	}
+}
+
+type fatalF interface {
+	Fatalf(format string, args ...interface{})
+}
+
+func getBaseData(b fatalF) []byte {
+	cust := base.NewCustomer()
+	buf, err := json.MarshalIndent(&cust, "", "    ")
+	if err != nil {
+		b.Fatalf("Marshal: %v", err)
+	}
+	return buf
+}
+
+func BenchmarkUnmarshalJSON(b *testing.B) {
+	rec := base.Customer{}
+	buf := getBaseData(b)
+	b.SetBytes(int64(len(buf)))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := json.Unmarshal(buf, &rec)
+		if err != nil {
+			b.Fatalf("Marshal: %v", err)
+		}
+	}
+}
+
+func BenchmarkFFUnmarshalJSON(b *testing.B) {
+	rec := ff.Customer{}
+	buf := getBaseData(b)
+	b.SetBytes(int64(len(buf)))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := rec.UnmarshalJSON(buf)
+		if err != nil {
+			b.Fatalf("UnmarshalJSON: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
This fixes never calling UnmarshalFFLexer for pointer types defined in different files.

It looks like an oversight to me, but maybe I'm missing some good reason for why we shouldn't do this? The tests do seem to pass.

This brings the example (stripe, split into separate files per type) from a slow-down of 2.5 to a speed-up of 2.5.

Would you prefer I order the files by dependency in the Makefile, and just run ffjson once? This seems more robust.

It would be nice to have a warning in the documentation against the potential slow-down when not fully ffjson-izing a struct somewhere. Also that you should run ffjson twice or in the right order if you're dealing with multiple files. (Looking forward to the directory PR, but this still applies across package boundaries.)

 From my profiling of the pre-fix benchmark, it seems most time is spent with the buffer pool. Could well be that there's improvements to be made at that level.
