### PR TITLE
On unmarshaling interface{}.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ ffize: install
 
 bench: ffize all
 	go test -v -benchmem -bench MarshalJSON  github.com/pquerna/ffjson/tests
+	go test -v -benchmem -bench Unmarshal  github.com/pquerna/ffjson/tests
 	go test -v -benchmem -bench MarshalJSON  github.com/pquerna/ffjson/tests/goser github.com/pquerna/ffjson/tests/go.stripe
 	go test -v -benchmem -bench UnmarshalJSON  github.com/pquerna/ffjson/tests/goser github.com/pquerna/ffjson/tests/go.stripe
 

--- a/tests/base.go
+++ b/tests/base.go
@@ -13,4 +13,5 @@ type Record struct {
 	ServerIp  string
 	RemoteIp  string
 	BytesSent uint64
+	Ext       interface{}
 }

--- a/tests/ff.go
+++ b/tests/ff.go
@@ -35,6 +35,7 @@ type FFRecord struct {
 	ServerIp  string
 	RemoteIp  string
 	BytesSent uint64
+	Ext       interface{}
 }
 
 // ffjson: skip

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -161,8 +161,8 @@ func BenchmarkSimpleUnmarshal(b *testing.B) {
 	}
 }
 
-func BenchmarkSXimpleUnmarshalNative(b *testing.B) {
-	record := newLogRecord()
+func BenchmarkSimpleUnmarshalNative(b *testing.B) {
+	record := newLogFFRecord()
 	buf := []byte(`{"id": 123213, "OriginId": 22, "meth": "GET"}`)
 	err := json.Unmarshal(buf, record)
 	if err != nil {

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -40,6 +40,10 @@ func newLogRecord() *Record {
 	return &Record{
 		OriginId: 11,
 		Method:   "POST",
+		Ext: map[string]interface{}{
+			"a": []int{3, 4, 5},
+			"b": "what?",
+		},
 	}
 }
 
@@ -47,8 +51,14 @@ func newLogFFRecord() *FFRecord {
 	return &FFRecord{
 		OriginId: 11,
 		Method:   "POST",
+		Ext: map[string]interface{}{
+			"a": []int{3, 4, 5},
+			"b": "what?",
+		},
 	}
 }
+
+var marshaled = `{"id": 123213, "OriginId": 22, "meth": "GET", "Ext": {"a": [3,"yay"], "b": null}}`
 
 func BenchmarkMarshalJSON(b *testing.B) {
 	record := newLogRecord()
@@ -145,7 +155,7 @@ func BenchmarkUnmarshalJSON(b *testing.B) {
 
 func BenchmarkSimpleUnmarshal(b *testing.B) {
 	record := newLogFFRecord()
-	buf := []byte(`{"id": 123213, "OriginId": 22, "meth": "GET"}`)
+	buf := []byte(marshaled)
 	err := record.UnmarshalJSON(buf)
 	if err != nil {
 		b.Fatalf("UnmarshalJSON: %v", err)
@@ -163,7 +173,7 @@ func BenchmarkSimpleUnmarshal(b *testing.B) {
 
 func BenchmarkSimpleUnmarshalNative(b *testing.B) {
 	record := newLogFFRecord()
-	buf := []byte(`{"id": 123213, "OriginId": 22, "meth": "GET"}`)
+	buf := []byte(marshaled)
 	err := json.Unmarshal(buf, record)
 	if err != nil {
 		b.Fatalf("json.Unmarshal: %v", err)
@@ -207,7 +217,7 @@ func TestUnmarshalFaster(t *testing.T) {
 func TestSimpleUnmarshal(t *testing.T) {
 	record := newLogFFRecord()
 
-	err := record.UnmarshalJSON([]byte(`{"id": 123213, "OriginId": 22, "meth": "GET"}`))
+	err := record.UnmarshalJSON([]byte(marshaled))
 	if err != nil {
 		t.Fatalf("UnmarshalJSON: %v", err)
 	}
@@ -222,6 +232,29 @@ func TestSimpleUnmarshal(t *testing.T) {
 
 	if record.Method != "GET" {
 		t.Fatalf("record.Method: expected: GET got: %v", record.Method)
+	}
+
+	ext, ok := record.Ext.(map[string]interface{})
+	if !ok {
+		t.Fatalf("record.Ext: expected map[string]interface{}, got %T", ext)
+	}
+
+	a, ok := ext["a"].([]interface{})
+	if !ok {
+		t.Fatalf(`record.Ext["a"]: expected []interface{}, got %T`, ext["a"])
+	}
+
+	if len(a) != 2 {
+		t.Fatalf(`record.Ext["a"]: expected slice of length 3, got %d`, len(a))
+	}
+	if a0, ok := a[0].(float64); !ok || a0 != 3 {
+		t.Fatalf(`record.Ext["a"][0]: expected 3, got %v`, a[0])
+	}
+	if a1, ok := a[1].(string); !ok || a1 != "yay" {
+		t.Fatalf(`record.Ext["a"][1]: expected "yay", got %v`, a[1])
+	}
+	if ext["b"] != nil {
+		t.Fatalf(`record.Ext["b"]: expected nil, got %v`, ext["b"])
 	}
 }
 

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -125,6 +125,24 @@ func BenchmarkMarshalJSONNativeReuse(b *testing.B) {
 	}
 }
 
+func BenchmarkUnmarshalJSON(b *testing.B) {
+	record := newLogRecord()
+	buf := []byte(`{"id": 123213, "OriginId": 22, "meth": "GET"}`)
+	err := json.Unmarshal(buf, record)
+	if err != nil {
+		b.Fatalf("json.Unmarshal: %v", err)
+	}
+	b.SetBytes(int64(len(buf)))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := json.Unmarshal(buf, record)
+		if err != nil {
+			b.Fatalf("json.UnmarshalO: %v", err)
+		}
+	}
+}
+
 func BenchmarkSimpleUnmarshal(b *testing.B) {
 	record := newLogFFRecord()
 	buf := []byte(`{"id": 123213, "OriginId": 22, "meth": "GET"}`)


### PR DESCRIPTION
This is more of a bug report than a PR right now... With the `interface{}` field in there, unmarshalling becomes horribly slow:

```
$ go test -v -run=None -benchmem -bench Unmarshal  github.com/pquerna/ffjson/tests 
PASS
BenchmarkUnmarshalJSON    300000          4080 ns/op      11.03 MB/s         264 B/op          5 allocs/op
BenchmarkSimpleUnmarshal      100000         13168 ns/op       6.15 MB/s        1435 B/op         32 allocs/op
BenchmarkSimpleUnmarshalNative    100000         12469 ns/op       6.50 MB/s        1435 B/op         32 allocs/op
ok      github.com/pquerna/ffjson/tests 4.114s
```

From what I've read so far, I guess this would best be addressed by writing

```
func UnmarshalInterface(ffl *FFLexer, start FFTok) (interface{}, error)
```

modeled on `FFLexer.CaptureField`?
