### PR TITLE
Add reusable Encoder API, similar to encoding/json

### DIFF
--- a/ffjson/encoder.go
+++ b/ffjson/encoder.go
@@ -1,0 +1,201 @@
+package ffjson
+
+/**
+ *  Copyright 2015 Paul Querna, Klaus Post
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+import (
+	"encoding/json"
+	"errors"
+	fflib "github.com/pquerna/ffjson/fflib/v1"
+	"io"
+	"reflect"
+	"sync"
+)
+
+// This is a reusable encoder.
+// It allows to encode many objects to a single writer.
+// This should not be used by more than one goroutine at the time.
+type Encoder struct {
+	buf fflib.Buffer
+	w   io.Writer
+	enc *json.Encoder
+}
+
+// NewEncoder returns a reusable Encoder.
+// Output will be written to the supplied writer.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{w: w, enc: json.NewEncoder(w)}
+}
+
+// Encode the data in the supplied value to the stream
+// given on creation.
+func (e *Encoder) Encode(v interface{}) error {
+	f, ok := v.(marshalerFaster)
+	if ok {
+		e.buf.Reset()
+		err := f.MarshalJSONBuf(&e.buf)
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(e.w, &e.buf)
+		return err
+	}
+
+	return e.enc.Encode(v)
+}
+
+// EncodeFast will unmarshal the data if fast marshall is available.
+// This function can be used if you want to be sure the fast
+// marshal is used or in testing.
+// If you would like to have fallback to encoding/json you can use the
+// regular Encode() method.
+func (e *Encoder) EncodeFast(v interface{}) error {
+	_, ok := v.(marshalerFaster)
+	if !ok {
+		return errors.New("ffjson marshal not available for type " + reflect.TypeOf(v).String())
+	}
+	return e.Encode(v)
+}
+
+// Error returned on async encodings.
+// It contains the object and the error received to assist in debugging.
+type ErrEncoderAsync struct {
+	Err        error
+	Object     interface{}
+	ObjectType string
+}
+
+// Returns the Error as readable string.
+func (e ErrEncoderAsync) Error() string {
+	return "encoding object of type '" + e.ObjectType + "':" + e.Err.Error()
+}
+
+func newErrEncoderAsync(err error, v interface{}) error {
+	return ErrEncoderAsync{Err: err, Object: v, ObjectType: reflect.TypeOf(v).String()}
+}
+
+// This is a reusable asynchronous encoder.
+// It allows to encode many objects to a single writer.
+// It will spawn a goroutine that will encode incoming
+// objects.
+//
+// This is *safe* to use by several goroutines at one,
+// although the order will of course not be predictable.
+//
+// If used by a single goroutine, the order written will be the order
+// given to Encode.
+type EncoderAsync struct {
+	enc      Encoder          // The encoder used
+	incoming chan interface{} // Channel of incoming objects
+	flush    chan bool        // flush signal
+	asyncerr error            // errors received during encoding
+	mu       sync.RWMutex     // protection for 'asyncerr'
+}
+
+// NewEncoderAsync returns a reusable asynchronous encoder.
+//
+// You can specify the number of buffered objects.
+// Output will be written to the supplied writer.
+func NewEncoderAsync(w io.Writer, buffer uint) *EncoderAsync {
+	e := EncoderAsync{enc: Encoder{w: w, enc: json.NewEncoder(w)}}
+
+	e.asyncerr = nil
+	e.incoming = make(chan interface{}, buffer)
+	e.flush = make(chan bool, 0)
+
+	go func() {
+		var err error
+		for {
+			select {
+			case v := <-e.incoming:
+				// If we already have an error, skip this.
+				if e.asyncerr == nil {
+					err = e.enc.Encode(v)
+					if err != nil {
+						e.mu.Lock()
+						e.asyncerr = newErrEncoderAsync(err, v)
+						e.mu.Unlock()
+					}
+				}
+			case <-e.flush:
+				end := false
+				for !end {
+					select {
+					case v := <-e.incoming:
+						err = e.enc.Encode(v)
+						if err != nil {
+							e.asyncerr = newErrEncoderAsync(err, v)
+							end = true
+						}
+					default:
+						end = true
+					}
+				}
+				e.flush <- true
+				return
+			}
+		}
+	}()
+
+	return &e
+}
+
+// Encode the data sent.
+//
+// The function will return immediately.
+//
+// If an error has occurred from encoding other objects,
+// this error will be returned, so a call might receive an error
+// that occurred while encoding a previous object.
+func (e *EncoderAsync) Encode(v interface{}) error {
+	e.mu.RLock()
+	if e.asyncerr != nil {
+		err := e.asyncerr
+		e.mu.RUnlock()
+		return err
+	}
+	e.mu.RUnlock()
+	e.incoming <- v
+	return nil
+}
+
+// Close will flush all pending encodes and write to output.
+// If an error occurred during encode, it will be returned.
+// This should only be called once for an encoder objects.
+func (e *EncoderAsync) Close() error {
+	e.mu.RLock()
+	if e.asyncerr != nil {
+		err := e.asyncerr
+		e.mu.RUnlock()
+		return err
+	}
+	e.mu.RUnlock()
+	// Send signal that we want to flush
+	// Will block until we are in "case e.flush"
+	e.flush <- true
+
+	// Wait for flush to finish.
+	<-e.flush
+	err := e.asyncerr
+
+	// Set this error, so it is returned, if the objct is re-used.
+	if err == nil {
+		e.asyncerr = errors.New("encoder closed")
+	}
+	return err
+}

--- a/tests/ff.go
+++ b/tests/ff.go
@@ -18,6 +18,7 @@
 package tff
 
 import (
+	"errors"
 	"math"
 	"time"
 )
@@ -588,6 +589,19 @@ type CText int
 
 func (CText) MarshalText() ([]byte, error) {
 	return []byte(`"<&>"`), nil
+}
+
+var ErrGiveError = errors.New("GiveError error")
+
+// GiveError always returns an ErrGiveError on Marshal/Unmarshal.
+type GiveError struct{}
+
+func (r GiveError) MarshalJSON() ([]byte, error) {
+	return nil, ErrGiveError
+}
+
+func (r *GiveError) UnmarshalJSON([]byte) error {
+	return ErrGiveError
 }
 
 type IntType int

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -192,33 +192,17 @@ func TestMarshalEncoder(t *testing.T) {
 	require.NotEqual(t, 0, out.Len(), "encoded buffer size should not be 0")
 }
 
-func TestMarshalAsyncEncoder(t *testing.T) {
-	record := newLogFFRecord()
-	out := bytes.Buffer{}
-	enc := ffjson.NewEncoderAsync(&out, 10)
-	for i := 0; i < 100; i++ {
-		err := enc.Encode(record)
-		require.NoError(t, err)
-	}
-	err := enc.Close()
-	require.NoError(t, err)
-	require.NotEqual(t, 0, out.Len(), "encoded buffer size should not be 0")
-	err = enc.Close()
-	require.Error(t, err, "Multiple close should fail")
-}
-
-func TestMarshalAsyncEncoderError(t *testing.T) {
+func TestMarshalEncoderError(t *testing.T) {
 	out := NopWriter{}
-	enc := ffjson.NewEncoderAsync(&out, 10)
-	// This *may* return an error, but current implementation does not
-	_ = enc.Encode(&GiveError{})
-	// This *must* return an error.
-	err := enc.Close()
-	require.Error(t, err, "expected error from encoder")
-	// .. and Encode should also return it.
-	err2 := enc.Encode(nil)
-	require.Error(t, err2, "expected error from encoder")
-	require.Equal(t, err, err2, "Expected to get same error from encoder")
+	enc := ffjson.NewEncoder(&out)
+	v := GiveError{}
+	err := enc.Encode(v)
+	require.Error(t, err, "excpected error from encoder")
+	err = enc.Encode(newLogFFRecord())
+	require.NoError(t, err, "error did not clear as expected.")
+
+	err = enc.EncodeFast(newLogRecord())
+	require.Error(t, err, "excpected error from encoder on type that isn't fast")
 }
 
 func TestUnmarshalFaster(t *testing.T) {


### PR DESCRIPTION
This also includes an async encoder that will encode objects from several goroutines to a single io.Writer.

The example on the from page would look like this - much cleaner, and similar to `encoding/json`.

```Go
import "github.com/pquerna/ffjson/ffjson"

func EncodeItems(items []Item, out io.Writer) {
    // We declare the buffer here, so it can be reused.
    var encoder := ffjson.NewEncoder(out)

    for _, item := range items {
        // Encode into the buffer
        _ = enc.Encode(&buffer)
    }
}
```.