### PR TITLE
Reduce lexer allocations

### DIFF
--- a/fflib/v1/jsonstring.go
+++ b/fflib/v1/jsonstring.go
@@ -35,10 +35,14 @@ type JsonStringWriter interface {
 	stringWriter
 }
 
+func WriteJsonString(buf JsonStringWriter, s string) {
+	WriteJson(buf, []byte(s))
+}
+
 /**
  * Function ported from encoding/json: func (e *encodeState) string(s string) (int, error)
  */
-func WriteJsonString(buf JsonStringWriter, s string) {
+func WriteJson(buf JsonStringWriter, s []byte) {
 	buf.WriteByte('"')
 	start := 0
 	for i := 0; i < len(s); {
@@ -55,7 +59,7 @@ func WriteJsonString(buf JsonStringWriter, s string) {
 			}
 
 			if start < i {
-				buf.WriteString(s[start:i])
+				buf.Write(s[start:i])
 			}
 			switch b {
 			case '\\', '"':
@@ -80,10 +84,10 @@ func WriteJsonString(buf JsonStringWriter, s string) {
 			start = i
 			continue
 		}
-		c, size := utf8.DecodeRuneInString(s[i:])
+		c, size := utf8.DecodeRune(s[i:])
 		if c == utf8.RuneError && size == 1 {
 			if start < i {
-				buf.WriteString(s[start:i])
+				buf.Write(s[start:i])
 			}
 			buf.WriteString(`\ufffd`)
 			i += size
@@ -99,7 +103,7 @@ func WriteJsonString(buf JsonStringWriter, s string) {
 		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
 		if c == '\u2028' || c == '\u2029' {
 			if start < i {
-				buf.WriteString(s[start:i])
+				buf.Write(s[start:i])
 			}
 			buf.WriteString(`\u202`)
 			buf.WriteByte(hex[c&0xF])
@@ -110,7 +114,7 @@ func WriteJsonString(buf JsonStringWriter, s string) {
 		i += size
 	}
 	if start < len(s) {
-		buf.WriteString(s[start:])
+		buf.Write(s[start:])
 	}
 	buf.WriteByte('"')
 }

--- a/fflib/v1/lexer.go
+++ b/fflib/v1/lexer.go
@@ -104,6 +104,7 @@ type FFLexer struct {
 	// TODO: convert all of this to an interface
 	lastCurrentChar int
 	captureAll      bool
+	buf             Buffer
 }
 
 func NewFFLexer(input []byte) *FFLexer {
@@ -247,15 +248,15 @@ func (ffl *FFLexer) lexComment() FFTok {
 
 func (ffl *FFLexer) lexString() FFTok {
 	if ffl.captureAll {
-		var buf Buffer
-		err := ffl.reader.SliceString(&buf)
+		ffl.buf.Reset()
+		err := ffl.reader.SliceString(&ffl.buf)
 
 		if err != nil {
 			ffl.BigError = err
 			return FFTok_error
 		}
 
-		WriteJsonString(ffl.Output, buf.String())
+		WriteJson(ffl.Output, ffl.buf.Bytes())
 
 		return FFTok_string
 	} else {
@@ -541,9 +542,9 @@ func (ffl *FFLexer) scanField(start FFTok, capture bool) ([]byte, error) {
 	case FFTok_string:
 		//TODO(pquerna): so, other users expect this to be a quoted string :(
 		if capture {
-			var buf Buffer
-			WriteJsonString(&buf, ffl.Output.String())
-			return buf.Bytes(), nil
+			ffl.buf.Reset()
+			WriteJson(&ffl.buf, ffl.Output.Bytes())
+			return ffl.buf.Bytes(), nil
 		} else {
 			return nil, nil
 		}


### PR DESCRIPTION
Refactor WriteJson from WriteJsonString accepts a byte array to avoid copying bytes to string in lexer.

Add internal buffer to the lexer to avoid allocations.