### PR TITLE
bytes package is not used if there are no fields.

### DIFF
--- a/inception/decoder.go
+++ b/inception/decoder.go
@@ -36,7 +36,9 @@ var validValues []string = []string{
 func CreateUnmarshalJSON(ic *Inception, si *StructInfo) error {
 	out := ""
 	ic.OutputImports[`fflib "github.com/pquerna/ffjson/fflib/v1"`] = true
-	ic.OutputImports[`"bytes"`] = true
+	if len(si.Fields) > 0 {
+		ic.OutputImports[`"bytes"`] = true
+	}
 	ic.OutputImports[`"fmt"`] = true
 
 	out += tplStr(decodeTpl["header"], header{


### PR DESCRIPTION
Fixes `imported and not used: "bytes"`