### PR TITLE
Go 1.2 backport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 script: make clean && make test && make test
 
 go:
+  - 1.2
   - 1.3
   - 1.4
   - tip

--- a/fflib/v1/buffer.go
+++ b/fflib/v1/buffer.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"sync"
 	"unicode/utf8"
 )
 
@@ -71,84 +70,6 @@ type DecodingBuffer interface {
 	grower
 	bytesReader
 	lener
-}
-
-var pools [14]sync.Pool
-var pool64 *sync.Pool
-
-func init() {
-	var i uint
-	// TODO(pquerna): add science here around actual pool sizes.
-	for i = 6; i < 20; i++ {
-		n := 1 << i
-		pools[poolNum(n)].New = func() interface{} { return make([]byte, 0, n) }
-	}
-	pool64 = &pools[0]
-}
-
-// This returns the pool number that will give a buffer of
-// at least 'i' bytes.
-func poolNum(i int) int {
-	// TODO(pquerna): convert to log2 w/ bsr asm instruction:
-	// 	<https://groups.google.com/forum/#!topic/golang-nuts/uAb5J1_y7ns>
-	if i <= 64 {
-		return 0
-	} else if i <= 128 {
-		return 1
-	} else if i <= 256 {
-		return 2
-	} else if i <= 512 {
-		return 3
-	} else if i <= 1024 {
-		return 4
-	} else if i <= 2048 {
-		return 5
-	} else if i <= 4096 {
-		return 6
-	} else if i <= 8192 {
-		return 7
-	} else if i <= 16384 {
-		return 8
-	} else if i <= 32768 {
-		return 9
-	} else if i <= 65536 {
-		return 10
-	} else if i <= 131072 {
-		return 11
-	} else if i <= 262144 {
-		return 12
-	} else if i <= 524288 {
-		return 13
-	} else {
-		return -1
-	}
-}
-
-// Send a buffer to the Pool to reuse for other instances.
-// You may no longer utilize the content of the buffer, since it may be used
-// by other goroutines.
-func Pool(b []byte) {
-	if b == nil {
-		return
-	}
-	c := cap(b)
-
-	// Our smallest buffer is 64 bytes, so we discard smaller buffers.
-	if c < 64 {
-		return
-	}
-
-	// We need to put the incoming buffer into the NEXT buffer,
-	// since a buffer guarantees AT LEAST the number of bytes available
-	// that is the top of this buffer.
-	// That is the reason for dividing the cap by 2, so it gets into the NEXT bucket.
-	// We add 2 to avoid rounding down if size is exactly power of 2.
-	pn := poolNum((c + 2) >> 1)
-	if pn != -1 {
-		pools[pn].Put(b[0:0])
-	}
-	// if we didn't have a slot for this []byte, we just drop it and let the GC
-	// take care of it.
 }
 
 // A Buffer is a variable-sized buffer of bytes with Read and Write methods.
@@ -304,22 +225,6 @@ func (b *Buffer) ReadFrom(r io.Reader) (n int64, err error) {
 		}
 	}
 	return n, nil // err is EOF, so return nil explicitly
-}
-
-// makeSlice allocates a slice of size n -- it will attempt to use a pool'ed
-// instance whenever possible.
-func makeSlice(n int) []byte {
-	if n <= 64 {
-		return pool64.Get().([]byte)[0:n]
-	}
-
-	pn := poolNum(n)
-
-	if pn != -1 {
-		return pools[pn].Get().([]byte)[0:n]
-	} else {
-		return make([]byte, n)
-	}
 }
 
 // WriteTo writes data to w until the buffer is drained or an error occurs.

--- a/fflib/v1/buffer_nopool.go
+++ b/fflib/v1/buffer_nopool.go
@@ -1,0 +1,11 @@
+// +build !go1.3
+
+package v1
+
+// Stub version of buffer_pool.go for Go 1.2, which doesn't have sync.Pool.
+
+func Pool(b []byte) {}
+
+func makeSlice(n int) []byte {
+	return make([]byte, n)
+}

--- a/fflib/v1/buffer_pool.go
+++ b/fflib/v1/buffer_pool.go
@@ -1,0 +1,105 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.3
+
+package v1
+
+// Allocation pools for Buffers.
+
+import "sync"
+
+var pools [14]sync.Pool
+var pool64 *sync.Pool
+
+func init() {
+	var i uint
+	// TODO(pquerna): add science here around actual pool sizes.
+	for i = 6; i < 20; i++ {
+		n := 1 << i
+		pools[poolNum(n)].New = func() interface{} { return make([]byte, 0, n) }
+	}
+	pool64 = &pools[0]
+}
+
+// This returns the pool number that will give a buffer of
+// at least 'i' bytes.
+func poolNum(i int) int {
+	// TODO(pquerna): convert to log2 w/ bsr asm instruction:
+	// 	<https://groups.google.com/forum/#!topic/golang-nuts/uAb5J1_y7ns>
+	if i <= 64 {
+		return 0
+	} else if i <= 128 {
+		return 1
+	} else if i <= 256 {
+		return 2
+	} else if i <= 512 {
+		return 3
+	} else if i <= 1024 {
+		return 4
+	} else if i <= 2048 {
+		return 5
+	} else if i <= 4096 {
+		return 6
+	} else if i <= 8192 {
+		return 7
+	} else if i <= 16384 {
+		return 8
+	} else if i <= 32768 {
+		return 9
+	} else if i <= 65536 {
+		return 10
+	} else if i <= 131072 {
+		return 11
+	} else if i <= 262144 {
+		return 12
+	} else if i <= 524288 {
+		return 13
+	} else {
+		return -1
+	}
+}
+
+// Send a buffer to the Pool to reuse for other instances.
+// You may no longer utilize the content of the buffer, since it may be used
+// by other goroutines.
+func Pool(b []byte) {
+	if b == nil {
+		return
+	}
+	c := cap(b)
+
+	// Our smallest buffer is 64 bytes, so we discard smaller buffers.
+	if c < 64 {
+		return
+	}
+
+	// We need to put the incoming buffer into the NEXT buffer,
+	// since a buffer guarantees AT LEAST the number of bytes available
+	// that is the top of this buffer.
+	// That is the reason for dividing the cap by 2, so it gets into the NEXT bucket.
+	// We add 2 to avoid rounding down if size is exactly power of 2.
+	pn := poolNum((c + 2) >> 1)
+	if pn != -1 {
+		pools[pn].Put(b[0:0])
+	}
+	// if we didn't have a slot for this []byte, we just drop it and let the GC
+	// take care of it.
+}
+
+// makeSlice allocates a slice of size n -- it will attempt to use a pool'ed
+// instance whenever possible.
+func makeSlice(n int) []byte {
+	if n <= 64 {
+		return pool64.Get().([]byte)[0:n]
+	}
+
+	pn := poolNum(n)
+
+	if pn != -1 {
+		return pools[pn].Get().([]byte)[0:n]
+	} else {
+		return make([]byte, n)
+	}
+}

--- a/fflib/v1/reader_scan_amd64.go
+++ b/fflib/v1/reader_scan_amd64.go
@@ -26,9 +26,12 @@ func scanStringSSE(s []byte, j int) (int, byte)
 var sse42 = haveSSE42()
 
 func scanString(s []byte, j int) (int, byte) {
-	if false && sse42 {
-		return scanStringSSE(s, j)
-	}
+	// XXX The following fails to compile on Go 1.2.
+	/*
+		if false && sse42 {
+			return scanStringSSE(s, j)
+		}
+	*/
 
 	for {
 		if j >= len(s) {


### PR DESCRIPTION
I wanted to use ffjson on Go 1.2, which is the version shipped by Ubuntu 14.10. This set of patches fixes the build on that Go version (and corrects a small mistake in the README). It mostly shuffles some code around, but I also had to comment out a call to the assembler routine `scanStringSSE`, which the build system wasn't picking up.