### PR TITLE
Added support for unmarshaling complex maps

### DIFF
--- a/inception/decoder.go
+++ b/inception/decoder.go
@@ -195,10 +195,11 @@ func handleFieldAddr(ic *Inception, name string, takeAddr bool, typ reflect.Type
 		})
 	case reflect.Map:
 		out += tplStr(decodeTpl["handleObject"], handleObject{
-			IC:   ic,
-			Name: name,
-			Typ:  typ,
-			Ptr:  reflect.Ptr,
+			IC:       ic,
+			Name:     name,
+			Typ:      typ,
+			Ptr:      reflect.Ptr,
+			TakeAddr: takeAddr || ptr,
 		})
 	default:
 		ic.OutputImports[`"encoding/json"`] = true

--- a/inception/decoder.go
+++ b/inception/decoder.go
@@ -193,6 +193,13 @@ func handleFieldAddr(ic *Inception, name string, takeAddr bool, typ reflect.Type
 			Typ:  typ,
 			Kind: typ.Kind(),
 		})
+	case reflect.Map:
+		out += tplStr(decodeTpl["handleObject"], handleObject{
+			IC:   ic,
+			Name: name,
+			Typ:  typ,
+			Ptr:  reflect.Ptr,
+		})
 	default:
 		ic.OutputImports[`"encoding/json"`] = true
 		out += tplStr(decodeTpl["handleFallback"], handleFallback{
@@ -235,18 +242,11 @@ func getType(ic *Inception, name string, typ reflect.Type) string {
 	}
 
 	if s == "" {
-		switch typ.Kind() {
-		case reflect.Interface:
-			return "interface{}"
-		case reflect.Slice:
-			return "[]" + typ.Elem().String()
-		}
-		panic("non-numeric type " + typ.String() + " passed in w/o name: " + name)
+		return typ.String()
 	}
 
 	return s
 }
-
 
 func buildTokens(containsOptional bool, optional string, required ...string) []string {
 	if containsOptional {
@@ -271,4 +271,3 @@ func unquoteField(quoted bool) string {
 	}
 	return ""
 }
-

--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -147,6 +147,8 @@ func getGetInnerValue(ic *Inception, name string, typ reflect.Type, ptr bool, fo
 		out += tplStr(encodeTpl["handleMarshaler"], handleMarshaler{
 			IC:             ic,
 			Name:           name,
+			Typ:            typ,
+			Ptr:            reflect.Ptr,
 			MarshalJSONBuf: typ.Implements(marshalerFasterType) || reflect.PtrTo(typ).Implements(marshalerFasterType) || typeInInception(ic, typ, shared.MustEncoder),
 			Marshaler:      typ.Implements(marshalerType) || reflect.PtrTo(typ).Implements(marshalerType),
 		})
@@ -471,6 +473,11 @@ func CreateMarshalJSON(ic *Inception, si *StructInfo) error {
 	out += `func (mj *` + si.Name + `) MarshalJSON() ([]byte, error) {` + "\n"
 	out += `var buf fflib.Buffer` + "\n"
 
+	out += `if mh == nil {` + "\n"
+	out += `  buf.WriteString("null")` + "\n"
+	out += "  return buf, nil" + "\n"
+	out += `}` + "\n"
+
 	out += `err := mj.MarshalJSONBuf(&buf)` + "\n"
 	out += `if err != nil {` + "\n"
 	out += "  return nil, err" + "\n"
@@ -479,6 +486,11 @@ func CreateMarshalJSON(ic *Inception, si *StructInfo) error {
 	out += `}` + "\n"
 
 	out += `func (mj *` + si.Name + `) MarshalJSONBuf(buf fflib.EncodingBuffer) (error) {` + "\n"
+	out += `  if mh == nil {` + "\n"
+	out += `    buf.WriteString("null")` + "\n"
+	out += "    return buf, nil" + "\n"
+	out += `  }` + "\n"
+
 	out += `var err error` + "\n"
 	out += `var obj []byte` + "\n"
 	out += `_ = obj` + "\n"

--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -473,9 +473,9 @@ func CreateMarshalJSON(ic *Inception, si *StructInfo) error {
 	out += `func (mj *` + si.Name + `) MarshalJSON() ([]byte, error) {` + "\n"
 	out += `var buf fflib.Buffer` + "\n"
 
-	out += `if mh == nil {` + "\n"
+	out += `if mj == nil {` + "\n"
 	out += `  buf.WriteString("null")` + "\n"
-	out += "  return buf, nil" + "\n"
+	out += "  return buf.Bytes(), nil" + "\n"
 	out += `}` + "\n"
 
 	out += `err := mj.MarshalJSONBuf(&buf)` + "\n"
@@ -486,9 +486,9 @@ func CreateMarshalJSON(ic *Inception, si *StructInfo) error {
 	out += `}` + "\n"
 
 	out += `func (mj *` + si.Name + `) MarshalJSONBuf(buf fflib.EncodingBuffer) (error) {` + "\n"
-	out += `  if mh == nil {` + "\n"
+	out += `  if mj == nil {` + "\n"
 	out += `    buf.WriteString("null")` + "\n"
-	out += "    return buf, nil" + "\n"
+	out += "    return nil" + "\n"
 	out += `  }` + "\n"
 
 	out += `var err error` + "\n"

--- a/inception/encoder_tpl.go
+++ b/inception/encoder_tpl.go
@@ -18,6 +18,7 @@
 package ffjsoninception
 
 import (
+	"reflect"
 	"text/template"
 )
 
@@ -39,25 +40,32 @@ func init() {
 type handleMarshaler struct {
 	IC             *Inception
 	Name           string
+	Typ            reflect.Type
+	Ptr            reflect.Kind
 	MarshalJSONBuf bool
 	Marshaler      bool
 }
 
 var handleMarshalerTxt = `
-	{{if eq .MarshalJSONBuf true}}
 	{
+		{{if eq .Typ.Kind .Ptr}}
+		if {{.Name}} == nil {
+			buf.WriteString("null")
+			return nil
+		}
+		{{end}}
+
+		{{if eq .MarshalJSONBuf true}}
 		err = {{.Name}}.MarshalJSONBuf(buf)
 		if err != nil {
 			return err
 		}
-	}
-	{{else if eq .Marshaler true}}
-	{
+		{{else if eq .Marshaler true}}
 		obj, err = {{.Name}}.MarshalJSON()
 		if err != nil {
 			return err
 		}
 		buf.Write(obj)
+		{{end}}
 	}
-	{{end}}
 `


### PR DESCRIPTION
Pretty much as the title says, this PR adds support for unmarshaling types like `map[string]Struct` without falling back to `json.Unmarshal`.

The only change that might cause issues is https://github.com/pquerna/ffjson/compare/master...dancannon:master#diff-5f7254a247e449731c3927a3f5d524a3R245 if anybody has any better ideas let me know.