### PR TITLE
optimize FFLexer.wantBytes() and FFLexer.lexNumber()

### DIFF
--- a/fflib/v1/lexer.go
+++ b/fflib/v1/lexer.go
@@ -188,6 +188,7 @@ func (ffl *FFLexer) unreadByte() {
 }
 
 func (ffl *FFLexer) wantBytes(want []byte, iftrue FFTok) FFTok {
+	startPos := ffl.reader.Pos()
 	for _, b := range want {
 		c, err := ffl.readByte()
 
@@ -202,10 +203,10 @@ func (ffl *FFLexer) wantBytes(want []byte, iftrue FFTok) FFTok {
 			ffl.Error = FFErr_invalid_string
 			return FFTok_error
 		}
-
-		ffl.Output.WriteByte(c)
 	}
 
+	endPos := ffl.reader.Pos()
+	ffl.Output.Write(ffl.reader.Slice(startPos, endPos))
 	return iftrue
 }
 
@@ -284,6 +285,7 @@ func (ffl *FFLexer) lexString() FFTok {
 func (ffl *FFLexer) lexNumber() FFTok {
 	var numRead int = 0
 	tok := FFTok_integer
+	startPos := ffl.reader.Pos()
 
 	c, err := ffl.readByte()
 	if err != nil {
@@ -292,7 +294,6 @@ func (ffl *FFLexer) lexNumber() FFTok {
 
 	/* optional leading minus */
 	if c == '-' {
-		ffl.Output.WriteByte(c)
 		c, err = ffl.readByte()
 		if err != nil {
 			return FFTok_error
@@ -301,14 +302,12 @@ func (ffl *FFLexer) lexNumber() FFTok {
 
 	/* a single zero, or a series of integers */
 	if c == '0' {
-		ffl.Output.WriteByte(c)
 		c, err = ffl.readByte()
 		if err != nil {
 			return FFTok_error
 		}
 	} else if c >= '1' && c <= '9' {
 		for c >= '0' && c <= '9' {
-			ffl.Output.WriteByte(c)
 			c, err = ffl.readByte()
 			if err != nil {
 				return FFTok_error
@@ -322,14 +321,12 @@ func (ffl *FFLexer) lexNumber() FFTok {
 
 	if c == '.' {
 		numRead = 0
-		ffl.Output.WriteByte(c)
 		c, err = ffl.readByte()
 		if err != nil {
 			return FFTok_error
 		}
 
 		for c >= '0' && c <= '9' {
-			ffl.Output.WriteByte(c)
 			numRead++
 			c, err = ffl.readByte()
 			if err != nil {
@@ -350,8 +347,6 @@ func (ffl *FFLexer) lexNumber() FFTok {
 	/* optional exponent (indicates this is floating point) */
 	if c == 'e' || c == 'E' {
 		numRead = 0
-		ffl.Output.WriteByte(c)
-
 		c, err = ffl.readByte()
 		if err != nil {
 			return FFTok_error
@@ -359,7 +354,6 @@ func (ffl *FFLexer) lexNumber() FFTok {
 
 		/* optional sign */
 		if c == '+' || c == '-' {
-			ffl.Output.WriteByte(c)
 			c, err = ffl.readByte()
 			if err != nil {
 				return FFTok_error
@@ -367,7 +361,6 @@ func (ffl *FFLexer) lexNumber() FFTok {
 		}
 
 		for c >= '0' && c <= '9' {
-			ffl.Output.WriteByte(c)
 			numRead++
 			c, err = ffl.readByte()
 			if err != nil {
@@ -385,6 +378,8 @@ func (ffl *FFLexer) lexNumber() FFTok {
 
 	ffl.unreadByte()
 
+	endPos := ffl.reader.Pos()
+	ffl.Output.Write(ffl.reader.Slice(startPos, endPos))
 	return tok
 }
 

--- a/fflib/v1/reader.go
+++ b/fflib/v1/reader.go
@@ -40,6 +40,10 @@ func newffReader(d []byte) *ffReader {
 	}
 }
 
+func (r *ffReader) Slice(start, stop int) []byte {
+	return r.s[start:stop]
+}
+
 func (r *ffReader) Pos() int {
 	return r.i
 }


### PR DESCRIPTION
short story:
The idea behind the optimization is to replace multiple WriteByte(byte)
calls by single Write([]byte) call.

long story:
While profiling my application I noticed that some Buffer's functions
takes uncomfortable amount time. For example 10% for (*Buffer).grow().
Providing the lexer with preallocated buffer didn't change the picture.

```
...
2.90s  9.65% 34.31%      6.81s 22.66% github.com/pquerna/ffjson/fflib/v1.(*FFLexer).lexNumber
2.70s  8.99% 43.29%      2.88s  9.58% github.com/pquerna/ffjson/fflib/v1.(*Buffer).grow
2.60s  8.65% 51.95%      5.03s 16.74% github.com/pquerna/ffjson/fflib/v1.(*Buffer).WriteByte
2.16s  7.19% 59.13%     18.54s 61.70% github.com/pquerna/ffjson/fflib/v1.(*FFLexer).Scan
1.90s  6.32% 65.46%      1.90s  6.32% github.com/pquerna/ffjson/fflib/v1.(*ffReader).ReadByteNoWS
1.24s  4.13% 69.58%      1.24s  4.13% github.com/pquerna/ffjson/fflib/v1.(*Buffer).Reset
1.23s  4.09% 73.68%      1.23s  4.09% github.com/pquerna/ffjson/fflib/v1.scanString
1.15s  3.83% 77.50%      2.17s  7.22% github.com/pquerna/ffjson/fflib/v1.(*FFLexer).wantBytes
...
```

Further profiling and investigation showed that grow() is called for
each WriteByte() call. The later one is heavily used by lexer for
parsing a JSON document. But the hotspot was lexNumber() in my case
where WriteByte() is invoked for every character of a number (indeed,
the document I parsed contained thousands of unix timestamps which are
long numbers).

So, instead of calling WriteByte() after every parsed character my patch
makes the code to parse a number first and invoke Write([]byte) once for
the entire number. I also patched wantBytes() in similar fashion.

Profile after the change:

```
...
3.14s 10.45% 36.86%      4.53s 15.07% github.com/pquerna/ffjson/fflib/v1.(*FFLexer).lexNumber
2.53s  8.42% 45.28%     17.31s 57.58% github.com/pquerna/ffjson/fflib/v1.(*FFLexer).Scan
2.28s  7.58% 52.86%      2.28s  7.58% github.com/pquerna/ffjson/fflib/v1.(*ffReader).ReadByteNoWS
1.46s  4.86% 57.72%      1.46s  4.86% github.com/pquerna/ffjson/fflib/v1.scanString
1.22s  4.06% 61.78%      1.22s  4.06% github.com/pquerna/ffjson/fflib/v1.(*Buffer).Reset
1.10s  3.66% 65.44%      3.38s 11.24% github.com/pquerna/ffjson/fflib/v1.(*FFLexer).scanReadByte
1.08s  3.59% 69.03%      2.87s  9.55% github.com/pquerna/ffjson/fflib/v1.(*Buffer).Write
1.04s  3.46% 72.49%      1.25s  4.16% github.com/pquerna/ffjson/fflib/v1.(*Buffer).grow
...
```

Patched ffjson gave me 10-15% speed up.

Please note that some tests failed in master before the patch. So, I
didn't have nice test reports. But no new tests failed at least :-).