### PR TITLE
fix go1.6 compatibility problem in tests

### DIFF
--- a/tests/types/types_test.go
+++ b/tests/types/types_test.go
@@ -57,7 +57,7 @@ func TestRoundTrip(t *testing.T) {
 		t.Fatal("Embeded struct didn't Unmarshal")
 	}
 
-	if recordTripped.Something != 99 {
+	if recordTripped.Something != ff.ExpectedSomethingValue {
 		t.Fatal("Embeded nonexported-struct didn't Unmarshal")
 	}
 }
@@ -119,8 +119,9 @@ func TestUnmarshalFull(t *testing.T) {
 		t.Fatalf("record.String decoding problem, expected: %v got: %v", expect, record.String)
 	}
 
-	if record.Something != 99 {
-		t.Fatalf("record.Something decoding problem, expected: 99 got: %v", record.Something)
+	if record.Something != ff.ExpectedSomethingValue {
+		t.Fatalf("record.Something decoding problem, expected: %d got: %v",
+			ff.ExpectedSomethingValue, record.Something)
 	}
 }
 


### PR DESCRIPTION
https://tip.golang.org/doc/go1.6

The reflect package has resolved a long-standing incompatibility between
the gc and gccgo toolchains regarding embedded unexported struct types
containing exported fields. Code that walks data structures using
reflection, especially to implement serialization in the spirit of the
encoding/json and encoding/xml packages, may need to be updated.

The problem arises when using reflection to walk through an embedded
unexported struct-typed field into an exported field of that struct. In
this case, reflect had incorrectly reported the embedded field as exported,
by returning an empty Field.PkgPath. Now it correctly reports the field as
unexported but ignores that fact when evaluating access to exported fields
contained within the struct.

Updating: Typically, code that previously walked over structs and used

f.PkgPath != ""
to exclude inaccessible fields should now use

f.PkgPath != "" && !f.Anonymous
For example, see the changes to the implementations of encoding/json and
encoding/xml.

Also see code for more details