### PR TITLE
Eval symlinks in input files

### DIFF
--- a/generator/inceptionmain.go
+++ b/generator/inceptionmain.go
@@ -112,7 +112,11 @@ func getImportName(inputPath string) (string, error) {
 		return "", err
 	}
 
-	dpath := filepath.Dir(p)
+	dir := filepath.Dir(p)
+	dpath, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("Could not evaluate %s: %s", dir, err.Error()))
+	}
 
 	gopaths := strings.Split(os.Getenv("GOPATH"), string(os.PathListSeparator))
 


### PR DESCRIPTION
My `$GOPATH` is `~/golang`, but I also like to have all my projects in `~/projects`. That's why I symlink my projects from `$GOPATH` in `~/projects`.

All the go tools work without problems in a symlinked directory (`go *`, `golint`, `goerr`, `vim-go`, `gofmt`, `goimports`, ...) but `ffjson` fails with:

```
Error: error=Could not find source directory: GOPATH=[".../golang"] REL="..." path="":
```

This (minor) change allows ffjson to be executed in symlinked directories.