### PR TITLE
Add json.Number support, fix #153

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tests/go.stripe/ff/customer_ffjson.go
 tests/goser/ff/goser_ffjson.go
 tests/types/ff/everything_ffjson.go
+tests/number/ff/number_ffjson.go
 tests/ff_ffjson.go

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ ffize: install
 	ffjson tests/goser/ff/goser.go
 	ffjson tests/go.stripe/ff/customer.go
 	ffjson tests/types/ff/everything.go
+	ffjson tests/number/ff/number.go
 
 bench: ffize all
 	go test -v -benchmem -bench MarshalJSON  github.com/pquerna/ffjson/tests

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Please [open issues in Github](https://github.com/pquerna/ffjson/issues) for ide
 
 * [Klaus Post](https://github.com/klauspost)
 * [Paul Querna](https://github.com/pquerna) 
+* [Erik Dubbelboer](https://github.com/erikdubbelboer)
 
 ## License
 

--- a/tests/number/ff/number.go
+++ b/tests/number/ff/number.go
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2016 Paul Querna
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package ff
+
+import (
+	"encoding/json"
+)
+
+type Number struct {
+	Int   json.Number
+	Float json.Number
+}
+
+func NewNumber(e *Number) {
+	e.Int = "1"
+	e.Float = "3.14"
+}

--- a/tests/number/number_test.go
+++ b/tests/number/number_test.go
@@ -1,0 +1,69 @@
+/**
+ *  Copyright 2016 Paul Querna
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package types
+
+import (
+	"encoding/json"
+	ff "github.com/pquerna/ffjson/tests/number/ff"
+	"reflect"
+	"testing"
+)
+
+func TestRoundTrip(t *testing.T) {
+	var record ff.Number
+	var recordTripped ff.Number
+	ff.NewNumber(&record)
+
+	buf1, err := json.Marshal(&record)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	err = json.Unmarshal(buf1, &recordTripped)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	good := reflect.DeepEqual(record, recordTripped)
+	if !good {
+		t.Fatalf("Expected: %v\n Got: %v", record, recordTripped)
+	}
+}
+
+func TestUnmarshalEmpty(t *testing.T) {
+	record := ff.Number{}
+	err := record.UnmarshalJSON([]byte(`{}`))
+	if err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+}
+
+const (
+	numberJson = `{
+  "Int": 1,
+  "Float": 3.14
+}`
+)
+
+func TestUnmarshalFull(t *testing.T) {
+	record := ff.Number{}
+	err := record.UnmarshalJSON([]byte(numberJson))
+	if err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+}


### PR DESCRIPTION
Add support for [`json.Number`](https://golang.org/pkg/encoding/json/#Number) by falling back to `encoding/json`. This is done for the proper checking of the number using [isValidNumber()](https://github.com/golang/go/blob/f05c3aa24d815cd3869153750c9875e35fc48a6e/src/encoding/json/decode.go#L190). JSON numbers can be bigger than uint64.

To speed things up we could copy `isValidNumber` to our own source and handle it like a string. If you want me to make this change please let me know.