### PR TITLE
Fix *[]string type

### DIFF
--- a/inception/decoder.go
+++ b/inception/decoder.go
@@ -140,7 +140,7 @@ func handleFieldAddr(ic *Inception, name string, takeAddr bool, typ reflect.Type
 
 	case reflect.Array,
 		reflect.Slice:
-		out += getArrayHandler(ic, name, typ)
+		out += getArrayHandler(ic, name, typ, ptr)
 
 	case reflect.String:
 		// Is it a json.Number?
@@ -189,7 +189,7 @@ func handleFieldAddr(ic *Inception, name string, takeAddr bool, typ reflect.Type
 	return out
 }
 
-func getArrayHandler(ic *Inception, name string, typ reflect.Type) string {
+func getArrayHandler(ic *Inception, name string, typ reflect.Type, ptr bool) string {
 	if typ.Kind() == reflect.Slice && typ.Elem().Kind() == reflect.Uint8 {
 		ic.OutputImports[`"encoding/base64"`] = true
 		useReflectToSet := false
@@ -230,6 +230,7 @@ sliceOrArray:
 			IC:   ic,
 			Name: name,
 			Typ:  typ,
+			IsPtr: ptr,
 			Ptr:  reflect.Ptr,
 		})
 	}
@@ -238,6 +239,7 @@ sliceOrArray:
 		IC:   ic,
 		Name: name,
 		Typ:  typ,
+		IsPtr: ptr,
 		Ptr:  reflect.Ptr,
 	})
 }

--- a/inception/decoder_tpl.go
+++ b/inception/decoder_tpl.go
@@ -278,6 +278,7 @@ type handleArray struct {
 	Typ             reflect.Type
 	Ptr             reflect.Kind
 	UseReflectToSet bool
+	IsPtr bool
 }
 
 var handleArrayTxt = `
@@ -344,12 +345,18 @@ var handleSliceTxt = `
 	if tok == fflib.FFTok_null {
 		{{.Name}} = nil
 	} else {
-
-
 		{{if eq .Typ.Elem.Kind .Ptr }}
-			{{.Name}} = make([]*{{getType $ic .Name .Typ.Elem.Elem}}, 0)
+			{{if eq .IsPtr true}}
+				{{.Name}} = &[]*{{getType $ic .Name .Typ.Elem.Elem}}{}
+			{{else}}
+				{{.Name}} = []*{{getType $ic .Name .Typ.Elem.Elem}}{}
+			{{end}}
 		{{else}}
-			{{.Name}} = make([]{{getType $ic .Name .Typ.Elem}}, 0)
+			{{if eq .IsPtr true}}
+				{{.Name}} = &[]{{getType $ic .Name .Typ.Elem}}{}
+			{{else}}
+				{{.Name}} = []{{getType $ic .Name .Typ.Elem}}{}
+			{{end}}
 		{{end}}
 
 		wantVal := true
@@ -384,7 +391,11 @@ var handleSliceTxt = `
 			}
 
 			{{handleField .IC $tmpVar .Typ.Elem $ptr false}}
-			{{.Name}} = append({{.Name}}, {{$tmpVar}})
+			{{if eq .IsPtr true}}
+				*{{.Name}} = append(*{{.Name}}, {{$tmpVar}})
+			{{else}}
+				{{.Name}} = append({{.Name}}, {{$tmpVar}})
+			{{end}}
 			wantVal = false
 		}
 	}

--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -210,7 +210,7 @@ func getGetInnerValue(ic *Inception, name string, typ reflect.Type, ptr bool, fo
 			out += "buf.WriteString(`\"`)" + "\n"
 		} else {
 			out += "buf.WriteString(`[`)" + "\n"
-			out += "for i, v := range " + name + "{" + "\n"
+			out += "for i, v := range " + ptname + "{" + "\n"
 			out += "if i != 0 {" + "\n"
 			out += "buf.WriteString(`,`)" + "\n"
 			out += "}" + "\n"

--- a/tests/types/ff/everything.go
+++ b/tests/types/ff/everything.go
@@ -110,6 +110,7 @@ type Everything struct {
 	Float64          float64
 	Array            [2]int
 	Slice            []int
+	SlicePointer     *[]string
 	Map              map[string]int
 	String           string
 	StringPointer    *string
@@ -146,6 +147,7 @@ func NewEverything(e *Everything) {
 	e.Float64 = 3.15
 	e.Array = [2]int{11, 12}
 	e.Slice = []int{1, 2, 3}
+	e.SlicePointer = &[]string{"a", "b"}
 	e.Map = map[string]int{
 		"foo": 1,
 		"bar": 2,


### PR DESCRIPTION
encoding/json is able to handle pointers to slices, but ffjson generates code that doesn't compile.

```
type Foo struct {
   Bar *[]string
}
```

Here's a patch to get it working.