### PR TITLE
Fix Issue with multiple string tags

### DIFF
--- a/inception/encoder.go
+++ b/inception/encoder.go
@@ -238,10 +238,12 @@ func getGetInnerValue(ic *Inception, name string, typ reflect.Type, ptr bool, fo
 			if forceString {
 				// Forcestring on strings does double-escaping of the entire value.
 				// We create a temporary buffer, encode to that an re-encode it.
+				out += "{" + "\n"
 				out += "tmpbuf := fflib.Buffer{}" + "\n"
 				out += "tmpbuf.Grow(len(" + ptname + ") + 16)" + "\n"
 				out += "fflib.WriteJsonString(&tmpbuf, string(" + ptname + "))" + "\n"
 				out += "fflib.WriteJsonString(buf, string( tmpbuf.Bytes() " + `))` + "\n"
+				out += "}" + "\n"
 			} else {
 				out += "fflib.WriteJsonString(buf, string(" + ptname + "))" + "\n"
 			}


### PR DESCRIPTION
When a json tag includes a string type (e.g. `json:"field_name,string"`) a new buffer variable (_tmpbuf_) is used in the encoding procedure. 
Multiple string tags in one struct lead to invalid code created by _go generate_, due to repeating variable definitions (_no new variables on left side of :=_). 
This PR adds brackets around the definitions to restrict the scope of the (temporary) buffer variable.