### PR TITLE
inception: Reset undefined fields when reusing objects.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ test: ffize test-core
 	go test -v github.com/pquerna/ffjson/tests/...
 
 ffize: install
-	ffjson tests/ff.go
-	ffjson tests/goser/ff/goser.go
-	ffjson tests/go.stripe/ff/customer.go
-	ffjson tests/types/ff/everything.go
-	ffjson tests/number/ff/number.go
+	ffjson -force-regenerate tests/ff.go
+	ffjson -force-regenerate tests/goser/ff/goser.go
+	ffjson -force-regenerate tests/go.stripe/ff/customer.go
+	ffjson -force-regenerate -reset-fields tests/types/ff/everything.go
+	ffjson -force-regenerate tests/number/ff/number.go
 
 bench: ffize all
 	go test -v -benchmem -bench MarshalJSON  github.com/pquerna/ffjson/tests
@@ -39,6 +39,6 @@ bench: ffize all
 
 clean:
 	go clean -i github.com/pquerna/ffjson/...
-	rm -f tests/*/ff/*_ffjson.go tests/*_ffjson.go
+	rm -rf tests/ff/*_ffjson.go tests/*_ffjson.go tests/ffjson-inception*
 
 .PHONY: deps clean test fmt install all

--- a/ffjson.go
+++ b/ffjson.go
@@ -29,10 +29,11 @@ import (
 	"regexp"
 )
 
-var outputPathFlag      = flag.String("w", "", "Write generate code to this path instead of ${input}_ffjson.go.")
-var goCmdFlag           = flag.String("go-cmd", "", "Path to go command; Useful for `goapp` support.")
-var importNameFlag      = flag.String("import-name", "", "Override import name in case it cannot be detected.")
+var outputPathFlag = flag.String("w", "", "Write generate code to this path instead of ${input}_ffjson.go.")
+var goCmdFlag = flag.String("go-cmd", "", "Path to go command; Useful for `goapp` support.")
+var importNameFlag = flag.String("import-name", "", "Override import name in case it cannot be detected.")
 var forceRegenerateFlag = flag.Bool("force-regenerate", false, "Regenerate every input file, without checking modification date.")
+var resetFields = flag.Bool("reset-fields", false, "When unmarshalling reset all fields missing in the JSON")
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n\n", os.Args[0])
@@ -73,7 +74,7 @@ func main() {
 		importName = *importNameFlag
 	}
 
-	err := generator.GenerateFiles(goCmd, inputPath, outputPath, importName, *forceRegenerateFlag)
+	err := generator.GenerateFiles(goCmd, inputPath, outputPath, importName, *forceRegenerateFlag, *resetFields)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s:\n\n", err)

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -23,10 +23,10 @@ import (
 	"os"
 )
 
-func GenerateFiles(goCmd string, inputPath string, outputPath string, importName string, forceRegenerate bool) error {
+func GenerateFiles(goCmd string, inputPath string, outputPath string, importName string, forceRegenerate bool, resetFields bool) error {
 
 	if _, StatErr := os.Stat(outputPath); !os.IsNotExist(StatErr) {
-		inputFileInfo, inputFileErr   := os.Stat(inputPath)
+		inputFileInfo, inputFileErr := os.Stat(inputPath)
 		outputFileInfo, outputFileErr := os.Stat(outputPath)
 
 		if nil == outputFileErr && nil == inputFileErr {
@@ -43,7 +43,7 @@ func GenerateFiles(goCmd string, inputPath string, outputPath string, importName
 		return err
 	}
 
-	im := NewInceptionMain(goCmd, inputPath, outputPath)
+	im := NewInceptionMain(goCmd, inputPath, outputPath, resetFields)
 
 	err = im.Generate(packageName, structs, importName)
 	if err != nil {

--- a/generator/inceptionmain.go
+++ b/generator/inceptionmain.go
@@ -45,7 +45,7 @@ import (
 )
 
 func main() {
-	i := ffjsoninception.NewInception("{{.InputPath}}", "{{.PackageName}}", "{{.OutputPath}}")
+	i := ffjsoninception.NewInception("{{.InputPath}}", "{{.PackageName}}", "{{.OutputPath}}", {{.ResetFields}})
 	i.AddMany(importedinceptionpackage.FFJSONExpose())
 	i.Execute()
 }
@@ -83,6 +83,7 @@ type templateCtx struct {
 	PackageName string
 	InputPath   string
 	OutputPath  string
+	ResetFields bool
 }
 
 type InceptionMain struct {
@@ -94,15 +95,17 @@ type InceptionMain struct {
 	tempDir      string
 	tempMain     *os.File
 	tempExpose   *os.File
+	resetFields  bool
 }
 
-func NewInceptionMain(goCmd string, inputPath string, outputPath string) *InceptionMain {
+func NewInceptionMain(goCmd string, inputPath string, outputPath string, resetFields bool) *InceptionMain {
 	exposePath := getExposePath(inputPath)
 	return &InceptionMain{
-		goCmd:      goCmd,
-		inputPath:  inputPath,
-		outputPath: outputPath,
-		exposePath: exposePath,
+		goCmd:       goCmd,
+		inputPath:   inputPath,
+		outputPath:  outputPath,
+		exposePath:  exposePath,
+		resetFields: resetFields,
 	}
 }
 
@@ -192,6 +195,7 @@ func (im *InceptionMain) Generate(packageName string, si []*StructInfo, importNa
 		StructNames: sn,
 		InputPath:   im.inputPath,
 		OutputPath:  im.outputPath,
+		ResetFields: im.resetFields,
 	}
 
 	t := template.Must(template.New("inception.go").Parse(inceptionMainTemplate))

--- a/inception/decoder.go
+++ b/inception/decoder.go
@@ -52,6 +52,7 @@ func CreateUnmarshalJSON(ic *Inception, si *StructInfo) error {
 		SI:          si,
 		IC:          ic,
 		ValidValues: validValues,
+		ResetFields: ic.ResetFields,
 	})
 
 	ic.OutputFuncs = append(ic.OutputFuncs, out)
@@ -227,20 +228,20 @@ sliceOrArray:
 
 	if typ.Kind() == reflect.Array {
 		return tplStr(decodeTpl["handleArray"], handleArray{
-			IC:   ic,
-			Name: name,
-			Typ:  typ,
+			IC:    ic,
+			Name:  name,
+			Typ:   typ,
 			IsPtr: ptr,
-			Ptr:  reflect.Ptr,
+			Ptr:   reflect.Ptr,
 		})
 	}
 
 	return tplStr(decodeTpl["handleSlice"], handleArray{
-		IC:   ic,
-		Name: name,
-		Typ:  typ,
+		IC:    ic,
+		Name:  name,
+		Typ:   typ,
 		IsPtr: ptr,
-		Ptr:  reflect.Ptr,
+		Ptr:   reflect.Ptr,
 	})
 }
 

--- a/inception/inception.go
+++ b/inception/inception.go
@@ -36,9 +36,10 @@ type Inception struct {
 	OutputImports map[string]bool
 	OutputFuncs   []string
 	q             ConditionalWrite
+	ResetFields   bool
 }
 
-func NewInception(inputPath string, packageName string, outputPath string) *Inception {
+func NewInception(inputPath string, packageName string, outputPath string, resetFields bool) *Inception {
 	return &Inception{
 		objs:          make([]*StructInfo, 0),
 		InputPath:     inputPath,
@@ -46,6 +47,7 @@ func NewInception(inputPath string, packageName string, outputPath string) *Ince
 		PackageName:   packageName,
 		OutputFuncs:   make([]string, 0),
 		OutputImports: make(map[string]bool),
+		ResetFields:   resetFields,
 	}
 }
 


### PR DESCRIPTION
When reusing objects with sync.Pool, for example, and unmarshaling
objects, this resets the old fields, which are not defined in the
current JSON to their Zero values.

For example:

```
type M struct {
     Y []int
}

type A struct {
     I int
 T *M
}

type B struct {
     X int
     Z *A    `json:"Z,omitempty"`
     Y int   `json:"Y,omitempty"`
     K []int `json:"K,omitempty"`
}

buf0 = []byte(`{"X":1,"Z":{"I":3, "T":[3,4]},"Y":4,"K":[1,2,3]}`)
buf1 = []byte(`{"X":1,"K":[1,2,3]}`)

x0 := B{}
x0.UnmarshalJSON(buf0)
x1 := x0
x1.UnmarshalJSON(buf1)
```
- This ensures that x0 != x1 by setting the fields in x1.Z = nil and x1.Y = 0
  after marshalling all JSON objects.
