### PR TITLE
Don't Pool buffers that are still in use

### DIFF
--- a/fflib/v1/buffer.go
+++ b/fflib/v1/buffer.go
@@ -148,9 +148,9 @@ func (b *Buffer) grow(n int) int {
 			// not enough space anywhere
 			buf = makeSlice(2*cap(b.buf) + n)
 			copy(buf, b.buf[b.off:])
+			Pool(b.buf)
+			b.buf = buf
 		}
-		Pool(b.buf)
-		b.buf = buf
 		b.off = 0
 	}
 	b.buf = b.buf[0 : b.off+m+n]


### PR DESCRIPTION
In some cases `Pool` was being called while the buffer wasn't resized and thus still in use. I found this while trying to see what was wrong with #203.