### PR TITLE
Add strict option

### DIFF
--- a/ffjson.go
+++ b/ffjson.go
@@ -31,9 +31,10 @@ import (
 
 var outputPathFlag = flag.String("w", "", "Write generate code to this path instead of ${input}_ffjson.go.")
 var goCmdFlag = flag.String("go-cmd", "", "Path to go command; Useful for `goapp` support.")
+var strictDecodeFlag = flag.Bool("strict", false, "Returns an error when trying to decode unknow fields.")
 var importNameFlag = flag.String("import-name", "", "Override import name in case it cannot be detected.")
 var forceRegenerateFlag = flag.Bool("force-regenerate", false, "Regenerate every input file, without checking modification date.")
-var resetFields = flag.Bool("reset-fields", false, "When unmarshalling reset all fields missing in the JSON")
+var resetFields = flag.Bool("reset-fields", false, "When unmarshalling reset all fields missing in the JSON.")
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n\n", os.Args[0])
@@ -74,7 +75,7 @@ func main() {
 		importName = *importNameFlag
 	}
 
-	err := generator.GenerateFiles(goCmd, inputPath, outputPath, importName, *forceRegenerateFlag, *resetFields)
+	err := generator.GenerateFiles(goCmd, inputPath, outputPath, importName, *forceRegenerateFlag, *resetFields, *strictDecodeFlag)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s:\n\n", err)

--- a/fflib/v1/errors.go
+++ b/fflib/v1/errors.go
@@ -1,0 +1,18 @@
+package v1
+
+import "fmt"
+
+// ErrUnknowFields error is return when some unknow fields are found
+type ErrUnknowFields struct {
+	Fields []string
+}
+
+// NewErrUnknowFields create an instance UnknowFields error
+func NewErrUnknowFields(fields []string) *ErrUnknowFields {
+	return &ErrUnknowFields{
+		Fields: fields,
+	}
+}
+func (e *ErrUnknowFields) Error() string {
+	return fmt.Sprintf("unknow fields %v", e.Fields)
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -18,13 +18,11 @@
 package generator
 
 import (
-	"errors"
 	"fmt"
 	"os"
 )
 
-func GenerateFiles(goCmd string, inputPath string, outputPath string, importName string, forceRegenerate bool, resetFields bool) error {
-
+func GenerateFiles(goCmd string, inputPath string, outputPath string, importName string, forceRegenerate bool, resetFields bool, strict bool) error {
 	if _, StatErr := os.Stat(outputPath); !os.IsNotExist(StatErr) {
 		inputFileInfo, inputFileErr := os.Stat(inputPath)
 		outputFileInfo, outputFileErr := os.Stat(outputPath)
@@ -43,11 +41,11 @@ func GenerateFiles(goCmd string, inputPath string, outputPath string, importName
 		return err
 	}
 
-	im := NewInceptionMain(goCmd, inputPath, outputPath, resetFields)
+	im := NewInceptionMain(goCmd, inputPath, outputPath, resetFields, strict)
 
 	err = im.Generate(packageName, structs, importName)
 	if err != nil {
-		return errors.New(fmt.Sprintf("error=%v path=%q", err, im.TempMainPath))
+		return fmt.Errorf("error=%v path=%q", err, im.TempMainPath)
 	}
 
 	err = im.Run()

--- a/generator/inceptionmain.go
+++ b/generator/inceptionmain.go
@@ -45,7 +45,7 @@ import (
 )
 
 func main() {
-	i := ffjsoninception.NewInception("{{.InputPath}}", "{{.PackageName}}", "{{.OutputPath}}", {{.ResetFields}})
+	i := ffjsoninception.NewInception("{{.InputPath}}", "{{.PackageName}}", "{{.OutputPath}}", {{.ResetFields}}, {{.Strict}})
 	i.AddMany(importedinceptionpackage.FFJSONExpose())
 	i.Execute()
 }
@@ -84,6 +84,7 @@ type templateCtx struct {
 	InputPath   string
 	OutputPath  string
 	ResetFields bool
+	Strict      bool
 }
 
 type InceptionMain struct {
@@ -96,9 +97,10 @@ type InceptionMain struct {
 	tempMain     *os.File
 	tempExpose   *os.File
 	resetFields  bool
+	strict       bool
 }
 
-func NewInceptionMain(goCmd string, inputPath string, outputPath string, resetFields bool) *InceptionMain {
+func NewInceptionMain(goCmd string, inputPath string, outputPath string, resetFields bool, strict bool) *InceptionMain {
 	exposePath := getExposePath(inputPath)
 	return &InceptionMain{
 		goCmd:       goCmd,
@@ -106,6 +108,7 @@ func NewInceptionMain(goCmd string, inputPath string, outputPath string, resetFi
 		outputPath:  outputPath,
 		exposePath:  exposePath,
 		resetFields: resetFields,
+		strict:      strict,
 	}
 }
 
@@ -191,6 +194,7 @@ func (im *InceptionMain) Generate(packageName string, si []*StructInfo, importNa
 		InputPath:   im.inputPath,
 		OutputPath:  im.outputPath,
 		ResetFields: im.resetFields,
+		Strict:      im.strict,
 	}
 
 	t := template.Must(template.New("inception.go").Parse(inceptionMainTemplate))

--- a/inception/decoder.go
+++ b/inception/decoder.go
@@ -53,6 +53,7 @@ func CreateUnmarshalJSON(ic *Inception, si *StructInfo) error {
 		IC:          ic,
 		ValidValues: validValues,
 		ResetFields: ic.ResetFields,
+		Strict:      ic.Strict,
 	})
 
 	ic.OutputFuncs = append(ic.OutputFuncs, out)

--- a/inception/inception.go
+++ b/inception/inception.go
@@ -20,11 +20,12 @@ package ffjsoninception
 import (
 	"errors"
 	"fmt"
-	"github.com/pquerna/ffjson/shared"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
+
+	"github.com/pquerna/ffjson/shared"
 )
 
 type Inception struct {
@@ -37,9 +38,10 @@ type Inception struct {
 	OutputFuncs   []string
 	q             ConditionalWrite
 	ResetFields   bool
+	Strict        bool
 }
 
-func NewInception(inputPath string, packageName string, outputPath string, resetFields bool) *Inception {
+func NewInception(inputPath string, packageName string, outputPath string, resetFields bool, strict bool) *Inception {
 	return &Inception{
 		objs:          make([]*StructInfo, 0),
 		InputPath:     inputPath,
@@ -48,6 +50,7 @@ func NewInception(inputPath string, packageName string, outputPath string, reset
 		OutputFuncs:   make([]string, 0),
 		OutputImports: make(map[string]bool),
 		ResetFields:   resetFields,
+		Strict:        strict,
 	}
 }
 


### PR DESCRIPTION
Add the option -strict to return an error when trying to parse unexpected fields.