### PR TITLE
Fix usage of vendored type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ go:
   - 1.7
   - 1.6
   - 1.5
+
+env:
+  - GO15VENDOREXPERIMENT=1

--- a/inception/decoder.go
+++ b/inception/decoder.go
@@ -270,7 +270,8 @@ func getType(ic *Inception, name string, typ reflect.Type) string {
 	s := typ.Name()
 
 	if typ.PkgPath() != "" && typ.PkgPath() != ic.PackagePath {
-		ic.OutputImports[`"`+typ.PkgPath()+`"`] = true
+		path := removeVendor(typ.PkgPath())
+		ic.OutputImports[`"`+path+`"`] = true
 		s = typ.String()
 	}
 
@@ -279,6 +280,18 @@ func getType(ic *Inception, name string, typ reflect.Type) string {
 	}
 
 	return s
+}
+
+// removeVendor removes everything before and including a '/vendor/'
+// substring in the package path.
+// This is needed becuase that full path can't be used in the
+// import statement.
+func removeVendor(path string) string {
+	i := strings.Index(path, "/vendor/")
+	if i == -1 {
+		return path
+	}
+	return path[i+8:]
 }
 
 func buildTokens(containsOptional bool, optional string, required ...string) []string {

--- a/tests/types/ff/everything.go
+++ b/tests/types/ff/everything.go
@@ -21,6 +21,8 @@ import (
 	"regexp"
 	"runtime"
 	"strconv"
+
+	"github.com/foo/vendored"
 )
 
 var ExpectedSomethingValue int8
@@ -128,6 +130,7 @@ type nonexported struct {
 
 type Foo struct {
 	Bar int
+	Baz vendored.Foo
 }
 
 func NewEverything(e *Everything) {
@@ -153,7 +156,7 @@ func NewEverything(e *Everything) {
 		"bar": 2,
 	}
 	e.String = "snowman->☃"
-	e.FooStruct = &Foo{Bar: 1}
+	e.FooStruct = &Foo{Bar: 1, Baz: vendored.Foo{A: "a", B: 1}}
 	e.Something = ExpectedSomethingValue
 	e.MySweetInterface = &Cats{}
 	e.MapMap = map[string]map[string]string{

--- a/tests/vendor/github.com/foo/vendored/vendored.go
+++ b/tests/vendor/github.com/foo/vendored/vendored.go
@@ -1,0 +1,6 @@
+package vendored
+
+type Foo struct {
+	A string
+	B int
+}


### PR DESCRIPTION
Package path is needed to be changed before importing it.
The package path of package github.com/a/b if it is in the
vendor directory will be $GOPATH/my/project/vendor/github.com/a/b.
That can't be used in the import statement.
This change trims everything before and including a path containing
a '/vendor/' in it.

Fixes #214