### PR TITLE
Fix encode and decode when slice has null structs

### DIFF
--- a/inception/decoder_tpl.go
+++ b/inception/decoder_tpl.go
@@ -724,22 +724,21 @@ var handleUnmarshalerTxt = `
 				{{if eq .TakeAddr true }}
 					{{.Name}} = nil
 				{{end}}
-				state = fflib.FFParse_after_value
-				goto mainparse
-		}
-		{{if eq .Typ.Kind .Ptr }}
-			if {{.Name}} == nil {
-				{{.Name}} = new({{getType $ic .Typ.Elem.Name .Typ.Elem}})
+		} else {
+			{{if eq .Typ.Kind .Ptr }}
+				if {{.Name}} == nil {
+					{{.Name}} = new({{getType $ic .Typ.Elem.Name .Typ.Elem}})
+				}
+			{{end}}
+			{{if eq .TakeAddr true }}
+				if {{.Name}} == nil {
+					{{.Name}} = new({{getType $ic .Typ.Name .Typ}})
+				}
+			{{end}}
+			err = {{.Name}}.UnmarshalJSONFFLexer(fs, fflib.FFParse_want_key)
+			if err != nil {
+				return err
 			}
-		{{end}}
-		{{if eq .TakeAddr true }}
-			if {{.Name}} == nil {
-				{{.Name}} = new({{getType $ic .Typ.Name .Typ}})
-			}
-		{{end}}
-		err = {{.Name}}.UnmarshalJSONFFLexer(fs, fflib.FFParse_want_key)
-		if err != nil {
-			return err
 		}
 		state = fflib.FFParse_after_value
 	}
@@ -750,23 +749,22 @@ var handleUnmarshalerTxt = `
 			{{if eq .TakeAddr true }}
 				{{.Name}} = nil
 			{{end}}
-			state = fflib.FFParse_after_value
-			goto mainparse
-		}
+		} else {
 
-		tbuf, err := fs.CaptureField(tok)
-		if err != nil {
-			return fs.WrapErr(err)
-		}
+			tbuf, err := fs.CaptureField(tok)
+			if err != nil {
+				return fs.WrapErr(err)
+			}
 
-		{{if eq .TakeAddr true }}
-		if {{.Name}} == nil {
-			{{.Name}} = new({{getType $ic .Typ.Name .Typ}})
-		}
-		{{end}}
-		err = {{.Name}}.UnmarshalJSON(tbuf)
-		if err != nil {
-			return fs.WrapErr(err)
+			{{if eq .TakeAddr true }}
+			if {{.Name}} == nil {
+				{{.Name}} = new({{getType $ic .Typ.Name .Typ}})
+			}
+			{{end}}
+			err = {{.Name}}.UnmarshalJSON(tbuf)
+			if err != nil {
+				return fs.WrapErr(err)
+			}
 		}
 		state = fflib.FFParse_after_value
 	}

--- a/inception/encoder_tpl.go
+++ b/inception/encoder_tpl.go
@@ -51,8 +51,7 @@ var handleMarshalerTxt = `
 		{{if eq .Typ.Kind .Ptr}}
 		if {{.Name}} == nil {
 			buf.WriteString("null")
-			return nil
-		}
+		} else {
 		{{end}}
 
 		{{if eq .MarshalJSONBuf true}}
@@ -66,6 +65,9 @@ var handleMarshalerTxt = `
 			return err
 		}
 		buf.Write(obj)
+		{{end}}
+		{{if eq .Typ.Kind .Ptr}}
+		}
 		{{end}}
 	}
 `

--- a/tests/ff.go
+++ b/tests/ff.go
@@ -147,6 +147,39 @@ type XslicePtr struct {
 	X []*int
 }
 
+// TMapStringPtr struct
+// ffjson: skip
+type TMapStringPtr struct {
+	X map[string]*int
+}
+
+// XMapStringPtr struct
+type XMapStringPtr struct {
+	X map[string]*int
+}
+
+// TslicePtrStruct struct
+// ffjson: skip
+type TslicePtrStruct struct {
+	X []*Xstring
+}
+
+// XslicePtrStruct struct
+type XslicePtrStruct struct {
+	X []*Xstring
+}
+
+// TMapPtrStruct struct
+// ffjson: skip
+type TMapPtrStruct struct {
+	X map[string]*Xstring
+}
+
+// XMapPtrStruct struct
+type XMapPtrStruct struct {
+	X map[string]*Xstring
+}
+
 // Tstring struct
 // ffjson: skip
 type Tstring struct {

--- a/tests/ff_test.go
+++ b/tests/ff_test.go
@@ -463,6 +463,30 @@ func TestSlicePtr(t *testing.T) {
 	testCycle(t, &TslicePtr{X: []*int{&v}}, &XslicePtr{X: []*int{}})
 }
 
+func TestSlicePtrNils(t *testing.T) {
+	v1 := 3
+	v2 := 4
+	testType(t, &TslicePtr{X: []*int{nil, &v1, nil, &v2}}, &XslicePtr{X: []*int{nil, &v1, nil, &v2}})
+}
+
+func TestMapPtrNils(t *testing.T) {
+	v1 := 3
+	v2 := 4
+	testType(t, &TMapStringPtr{X: map[string]*int{"a": nil, "b": &v1, "c": nil, "d": &v2}}, &XMapStringPtr{X: map[string]*int{"a": nil, "b": &v1, "c": nil, "d": &v2}})
+}
+
+func TestSlicePtrStructNils(t *testing.T) {
+	v1 := "v1"
+	v2 := "v2"
+	testType(t, &TslicePtrStruct{X: []*Xstring{nil, &Xstring{v1}, nil, &Xstring{v2}}}, &XslicePtrStruct{X: []*Xstring{nil, &Xstring{v1}, nil, &Xstring{v2}}})
+}
+
+func TestMapPtrStructNils(t *testing.T) {
+	v1 := "v1"
+	v2 := "v2"
+	testType(t, &TMapPtrStruct{X: map[string]*Xstring{"a": nil, "b": &Xstring{v1}, "c": nil, "d": &Xstring{v2}}}, &XMapPtrStruct{X: map[string]*Xstring{"a": nil, "b": &Xstring{v1}, "c": nil, "d": &Xstring{v2}}})
+}
+
 func TestTimeDuration(t *testing.T) {
 	testType(t, &Tduration{}, &Xduration{})
 }


### PR DESCRIPTION
If a struct contains a slice or map of structs,
this code can appear inside a for loop, and returning
from the entire function/going back to mainparse
generates invalid json/is unable to correctly parse
valid json.
Fixes #231