### PR TITLE
Fix test error on go 1.8+

### DIFF
--- a/tests/encode_test.go
+++ b/tests/encode_test.go
@@ -232,6 +232,27 @@ func TestDuplicatedFieldDisappears(t *testing.T) {
 	}
 }
 
+func TestRawMessage(t *testing.T) {
+	x := TRawMessage{json.RawMessage(`"foo"`)}
+
+	b, err := json.Marshal(&x)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `{"M":"foo"}`; string(b) != want {
+		t.Errorf("Marshal(&x) = %#q; want %#q", b, want)
+	}
+
+	b, err = json.Marshal(x)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := `{"M":"foo"}`; string(b) != want {
+		t.Errorf("Marshal(x) = %#q; want %#q", b, want)
+	}
+}
+
 func TestHTMLEscape(t *testing.T) {
 	var b, want bytes.Buffer
 	m := `{"M":"<html>foo &` + "\xe2\x80\xa8 \xe2\x80\xa9" + `</html>"}`

--- a/tests/encode_test.go
+++ b/tests/encode_test.go
@@ -232,30 +232,6 @@ func TestDuplicatedFieldDisappears(t *testing.T) {
 	}
 }
 
-func TestIssue6458(t *testing.T) {
-	type Foo struct {
-		M json.RawMessage
-	}
-	x := Foo{json.RawMessage(`"foo"`)}
-
-	b, err := json.Marshal(&x)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := `{"M":"foo"}`; string(b) != want {
-		t.Errorf("Marshal(&x) = %#q; want %#q", b, want)
-	}
-
-	b, err = json.Marshal(x)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if want := `{"M":"ImZvbyI="}`; string(b) != want {
-		t.Errorf("Marshal(x) = %#q; want %#q", b, want)
-	}
-}
-
 func TestHTMLEscape(t *testing.T) {
 	var b, want bytes.Buffer
 	m := `{"M":"<html>foo &` + "\xe2\x80\xa8 \xe2\x80\xa9" + `</html>"}`

--- a/tests/ff.go
+++ b/tests/ff.go
@@ -18,6 +18,7 @@
 package tff
 
 import (
+	"encoding/json"
 	"errors"
 	"math"
 	"time"
@@ -2304,4 +2305,9 @@ type XDominantField struct {
 	Other string
 	Name  *int             `json",omitempty"`
 	A     *struct{ X int } `json:"Name,omitempty"`
+}
+
+// TRawMessage struct
+type TRawMessage struct {
+	M json.RawMessage
 }


### PR DESCRIPTION
This test was testing the behavior of encoding/json, not ffjson, which changed in go 1.8: https://golang.org/doc/go1.8#encoding_json

I've added a test for ffjson instead.