### PR TITLE
Fix NaN bug and all broken tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 script: make clean && make lint && make test && make test 
 
 go:
-  - 1.7
+  - "1.10"
 
 env:
   - GO15VENDOREXPERIMENT=1

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ bench: ffize all
 
 clean:
 	go clean -i github.com/pquerna/ffjson/...
-	rm -rf tests/ff/*_ffjson.go tests/*_ffjson.go tests/ffjson-inception*
+	find . -name '*_ffjson.go' -delete
+	find . -name 'ffjson-inception*' -delete
 
 .PHONY: deps clean test fmt install all

--- a/fflib/v1/lexer.go
+++ b/fflib/v1/lexer.go
@@ -445,7 +445,6 @@ func (ffl *FFLexer) Scan() FFTok {
 			if ffl.captureAll {
 				ffl.Output.WriteByte(c)
 			}
-			break
 		case 't':
 			ffl.Output.WriteByte('t')
 			tok = ffl.wantBytes(true_bytes, FFTok_bool)
@@ -471,6 +470,7 @@ func (ffl *FFLexer) Scan() FFTok {
 		default:
 			tok = FFTok_error
 			ffl.Error = FFErr_invalid_char
+			goto lexed
 		}
 	}
 

--- a/tests/encode_test.go
+++ b/tests/encode_test.go
@@ -251,7 +251,7 @@ func TestIssue6458(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want := `{"M":"ImZvbyI="}`; string(b) != want {
+	if want := `{"M":"foo"}`; string(b) != want {
 		t.Errorf("Marshal(x) = %#q; want %#q", b, want)
 	}
 }

--- a/tests/fuzz_test.go
+++ b/tests/fuzz_test.go
@@ -149,11 +149,19 @@ func TestFuzzCycle(t *testing.T) {
 	rFF := FfFuzz{}
 	r := Fuzz{}
 	for i := 0; i < 1000; i++ {
-		if true || i > 0 {
-			// TODO: Re-enable after fixing:
-			// https://github.com/pquerna/ffjson/issues/82
+		if i > 0 {
 			f.RandSource(rand.New(rand.NewSource(int64(i * 324221))))
 			f.Fuzz(&r)
+
+			// TODO: remove these after we marshal 0.00000012 to 1.2e-7.
+			r.I = 0
+			r.J = 0
+			r.IP = nil
+			r.Jp = nil
+			r.Ia = []float32{0}
+			r.Ja = []float64{0}
+			r.Iap = nil
+			r.Jap = nil
 		}
 		rFF.A = r.A
 		rFF.B = r.B
@@ -242,6 +250,12 @@ func TestFuzzOmitCycle(t *testing.T) {
 		if i > 0 {
 			f.RandSource(rand.New(rand.NewSource(int64(i * 324221))))
 			f.Fuzz(&r)
+
+			// TODO: remove these after we marshal 0.00000012 to 1.2e-7.
+			r.J = 0
+			r.Jp = nil
+			r.Ja = []float64{0}
+			r.Jap = nil
 		}
 		rFF.A = r.A
 		rFF.B = r.B


### PR DESCRIPTION
I have combined all fixes I needed to do to make things testable again in the latest Go version. I thought this was better than making multiple pull requests. If you do want multiple separate ones let me know.

- Fix Makefile to remove all generated files on clean
- Return an error when trying to parse NaN (Fix #241)
- Fix marshalling of RawMessage test (Closes #234)
- Fix float errors in fuzz tests caused by default lib marshaling
  0.00000012 as 1.2e-7 while ffjson doesn't
- Remove invalid TODO